### PR TITLE
HashAlgorithm is an interface now

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -80,7 +80,7 @@ define "spymemcached" do
   manifest["Implementation-Vendor"] = COPYRIGHT
   manifest['Copyright'] = COPYRIGHT
   compile.with "log4j:log4j:jar:1.2.15", "jmock:jmock:jar:1.2.0",
-               "junit:junit:jar:4.4", "org.jboss.netty:netty:jar:3.1.5.GA",
+               "junit:junit:jar:4.7", "org.jboss.netty:netty:jar:3.1.5.GA",
                "org.springframework:spring-beans:jar:3.0.3.RELEASE",
                "org.codehaus.jettison:jettison:jar:1.1",
                "commons-codec:commons-codec:jar:1.5",

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -46,7 +46,7 @@ public class DefaultConnectionFactory extends SpyObject
 	/**
 	 * Default hash algorithm.
 	 */
-	public static final HashAlgorithm DEFAULT_HASH = HashAlgorithm.NATIVE_HASH;
+	public static final HashAlgorithm DEFAULT_HASH = DefaultHashAlgorithm.NATIVE_HASH;
 
 	/**
 	 * Maximum length of the operation queue returned by this connection
@@ -110,12 +110,19 @@ public class DefaultConnectionFactory extends SpyObject
 	}
 
 	/**
+     * Create a DefaultConnectionFactory with the given HashAlgorithm
+     * and default parameters
+     */
+    public DefaultConnectionFactory(HashAlgorithm hash) {
+        this(DEFAULT_OP_QUEUE_LEN, DEFAULT_READ_BUFFER_SIZE, hash);
+    }
+	/**
 	 * Create a DefaultConnectionFactory with the default parameters.
 	 */
 	public DefaultConnectionFactory() {
 		this(DEFAULT_OP_QUEUE_LEN, DEFAULT_READ_BUFFER_SIZE);
 	}
-
+	
 	public MemcachedNode createMemcachedNode(SocketAddress sa,
 			SocketChannel c, int bufSize) {
 

--- a/src/main/java/net/spy/memcached/DefaultHashAlgorithm.java
+++ b/src/main/java/net/spy/memcached/DefaultHashAlgorithm.java
@@ -1,0 +1,147 @@
+package net.spy.memcached;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.zip.CRC32;
+
+/**
+ * Known hashing algorithms for locating a server for a key.
+ * Note that all hash algorithms return 64-bits of hash, but only the lower
+ * 32-bits are significant.  This allows a positive 32-bit number to be
+ * returned for all cases.
+ */
+public enum DefaultHashAlgorithm implements HashAlgorithm {
+
+	/**
+	 * Native hash (String.hashCode()).
+	 */
+	NATIVE_HASH,
+	/**
+	 * CRC32_HASH as used by the perl API. This will be more consistent both
+	 * across multiple API users as well as java versions, but is mostly likely
+	 * significantly slower.
+	 */
+	CRC32_HASH,
+	/**
+	 * FNV hashes are designed to be fast while maintaining a low collision
+	 * rate. The FNV speed allows one to quickly hash lots of data while
+	 * maintaining a reasonable collision rate.
+	 *
+	 * @see <a href="http://www.isthe.com/chongo/tech/comp/fnv/">fnv comparisons</a>
+	 * @see <a href="http://en.wikipedia.org/wiki/Fowler_Noll_Vo_hash">fnv at wikipedia</a>
+	 */
+	FNV1_64_HASH,
+	/**
+	 * Variation of FNV.
+	 */
+	FNV1A_64_HASH,
+	/**
+	 * 32-bit FNV1.
+	 */
+	FNV1_32_HASH,
+	/**
+	 * 32-bit FNV1a.
+	 */
+	FNV1A_32_HASH,
+	/**
+	 * MD5-based hash algorithm used by ketama.
+	 */
+	KETAMA_HASH;
+
+	private static final long FNV_64_INIT = 0xcbf29ce484222325L;
+	private static final long FNV_64_PRIME = 0x100000001b3L;
+
+	private static final long FNV_32_INIT = 2166136261L;
+	private static final long FNV_32_PRIME = 16777619;
+
+	private static MessageDigest MD5_DIGEST = null;
+
+	static {
+		try {
+			MD5_DIGEST = MessageDigest.getInstance("MD5");
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException("MD5 not supported", e);
+		}
+	}
+
+	/**
+	 * Compute the hash for the given key.
+	 *
+	 * @return a positive integer hash
+	 */
+	public long hash(final String k) {
+		long rv = 0;
+		switch (this) {
+			case NATIVE_HASH:
+				rv = k.hashCode();
+				break;
+			case CRC32_HASH:
+				// return (crc32(shift) >> 16) & 0x7fff;
+				CRC32 crc32 = new CRC32();
+				crc32.update(KeyUtil.getKeyBytes(k));
+				rv = (crc32.getValue() >> 16) & 0x7fff;
+				break;
+			case FNV1_64_HASH: {
+					// Thanks to pierre@demartines.com for the pointer
+					rv = FNV_64_INIT;
+					int len = k.length();
+					for (int i = 0; i < len; i++) {
+						rv *= FNV_64_PRIME;
+						rv ^= k.charAt(i);
+					}
+				}
+				break;
+			case FNV1A_64_HASH: {
+					rv = FNV_64_INIT;
+					int len = k.length();
+					for (int i = 0; i < len; i++) {
+						rv ^= k.charAt(i);
+						rv *= FNV_64_PRIME;
+					}
+				}
+				break;
+			case FNV1_32_HASH: {
+					rv = FNV_32_INIT;
+					int len = k.length();
+					for (int i = 0; i < len; i++) {
+						rv *= FNV_32_PRIME;
+						rv ^= k.charAt(i);
+					}
+				}
+				break;
+			case FNV1A_32_HASH: {
+					rv = FNV_32_INIT;
+					int len = k.length();
+					for (int i = 0; i < len; i++) {
+						rv ^= k.charAt(i);
+						rv *= FNV_32_PRIME;
+					}
+				}
+				break;
+			case KETAMA_HASH:
+				byte[] bKey=computeMd5(k);
+				rv = ((long) (bKey[3] & 0xFF) << 24)
+						| ((long) (bKey[2] & 0xFF) << 16)
+						| ((long) (bKey[1] & 0xFF) << 8)
+						| (bKey[0] & 0xFF);
+				break;
+			default:
+				assert false;
+		}
+		return rv & 0xffffffffL; /* Truncate to 32-bits */
+	}
+
+	/**
+	 * Get the md5 of the given key.
+	 */
+	public static byte[] computeMd5(String k) {
+		MessageDigest md5;
+		try {
+			md5 = (MessageDigest)MD5_DIGEST.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new RuntimeException("clone of MD5 not supported", e);
+		}
+		md5.update(KeyUtil.getKeyBytes(k));
+		return md5.digest();
+	}
+}

--- a/src/main/java/net/spy/memcached/HashAlgorithm.java
+++ b/src/main/java/net/spy/memcached/HashAlgorithm.java
@@ -1,147 +1,15 @@
 package net.spy.memcached;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.zip.CRC32;
 
 /**
- * Known hashing algorithms for locating a server for a key.
- * Note that all hash algorithms return 64-bits of hash, but only the lower
- * 32-bits are significant.  This allows a positive 32-bit number to be
- * returned for all cases.
+ * Intents to provide hash for locating a server for a key.
  */
-public enum HashAlgorithm {
-
-	/**
-	 * Native hash (String.hashCode()).
-	 */
-	NATIVE_HASH,
-	/**
-	 * CRC32_HASH as used by the perl API. This will be more consistent both
-	 * across multiple API users as well as java versions, but is mostly likely
-	 * significantly slower.
-	 */
-	CRC32_HASH,
-	/**
-	 * FNV hashes are designed to be fast while maintaining a low collision
-	 * rate. The FNV speed allows one to quickly hash lots of data while
-	 * maintaining a reasonable collision rate.
-	 *
-	 * @see <a href="http://www.isthe.com/chongo/tech/comp/fnv/">fnv comparisons</a>
-	 * @see <a href="http://en.wikipedia.org/wiki/Fowler_Noll_Vo_hash">fnv at wikipedia</a>
-	 */
-	FNV1_64_HASH,
-	/**
-	 * Variation of FNV.
-	 */
-	FNV1A_64_HASH,
-	/**
-	 * 32-bit FNV1.
-	 */
-	FNV1_32_HASH,
-	/**
-	 * 32-bit FNV1a.
-	 */
-	FNV1A_32_HASH,
-	/**
-	 * MD5-based hash algorithm used by ketama.
-	 */
-	KETAMA_HASH;
-
-	private static final long FNV_64_INIT = 0xcbf29ce484222325L;
-	private static final long FNV_64_PRIME = 0x100000001b3L;
-
-	private static final long FNV_32_INIT = 2166136261L;
-	private static final long FNV_32_PRIME = 16777619;
-
-	private static MessageDigest MD5_DIGEST = null;
-
-	static {
-		try {
-			MD5_DIGEST = MessageDigest.getInstance("MD5");
-		} catch (NoSuchAlgorithmException e) {
-			throw new RuntimeException("MD5 not supported", e);
-		}
-	}
+public interface HashAlgorithm {
 
 	/**
 	 * Compute the hash for the given key.
 	 *
 	 * @return a positive integer hash
 	 */
-	public long hash(final String k) {
-		long rv = 0;
-		switch (this) {
-			case NATIVE_HASH:
-				rv = k.hashCode();
-				break;
-			case CRC32_HASH:
-				// return (crc32(shift) >> 16) & 0x7fff;
-				CRC32 crc32 = new CRC32();
-				crc32.update(KeyUtil.getKeyBytes(k));
-				rv = (crc32.getValue() >> 16) & 0x7fff;
-				break;
-			case FNV1_64_HASH: {
-					// Thanks to pierre@demartines.com for the pointer
-					rv = FNV_64_INIT;
-					int len = k.length();
-					for (int i = 0; i < len; i++) {
-						rv *= FNV_64_PRIME;
-						rv ^= k.charAt(i);
-					}
-				}
-				break;
-			case FNV1A_64_HASH: {
-					rv = FNV_64_INIT;
-					int len = k.length();
-					for (int i = 0; i < len; i++) {
-						rv ^= k.charAt(i);
-						rv *= FNV_64_PRIME;
-					}
-				}
-				break;
-			case FNV1_32_HASH: {
-					rv = FNV_32_INIT;
-					int len = k.length();
-					for (int i = 0; i < len; i++) {
-						rv *= FNV_32_PRIME;
-						rv ^= k.charAt(i);
-					}
-				}
-				break;
-			case FNV1A_32_HASH: {
-					rv = FNV_32_INIT;
-					int len = k.length();
-					for (int i = 0; i < len; i++) {
-						rv ^= k.charAt(i);
-						rv *= FNV_32_PRIME;
-					}
-				}
-				break;
-			case KETAMA_HASH:
-				byte[] bKey=computeMd5(k);
-				rv = ((long) (bKey[3] & 0xFF) << 24)
-						| ((long) (bKey[2] & 0xFF) << 16)
-						| ((long) (bKey[1] & 0xFF) << 8)
-						| (bKey[0] & 0xFF);
-				break;
-			default:
-				assert false;
-		}
-		return rv & 0xffffffffL; /* Truncate to 32-bits */
-	}
-
-	/**
-	 * Get the md5 of the given key.
-	 */
-	public static byte[] computeMd5(String k) {
-		MessageDigest md5;
-		try {
-			md5 = (MessageDigest)MD5_DIGEST.clone();
-		} catch (CloneNotSupportedException e) {
-			throw new RuntimeException("clone of MD5 not supported", e);
-		}
-		md5.update(KeyUtil.getKeyBytes(k));
-		return md5.digest();
-	}
+	long hash(final String k);
 }

--- a/src/main/java/net/spy/memcached/HashAlgorithmRegistry.java
+++ b/src/main/java/net/spy/memcached/HashAlgorithmRegistry.java
@@ -1,0 +1,61 @@
+package net.spy.memcached;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Registry of known hashing algorithms for locating a server for a key. Useful
+ * when configuring from files using algorithm names.
+ *
+ * <p>
+ * Please, make sure you register your algorithm with {
+ * {@link #registerHashAlgorithm(String, HashAlgorithm)} before referring to it
+ * by name
+ */
+public final class HashAlgorithmRegistry {
+
+	/**
+	 * Internal registry storage
+	 */
+	private static final Map<String, HashAlgorithm> REGISTRY = new HashMap<
+			String, HashAlgorithm>();
+	// initializing with the default algorithms implementation
+	static {
+		for (DefaultHashAlgorithm alg : DefaultHashAlgorithm.values()) {
+			registerHashAlgorithm(
+					alg.name().replace("[_HASH]$", "").toLowerCase(), alg);
+		}
+	}
+
+	/**
+	 * Registers provided {@link HashAlgorithm} instance with the given name.
+	 * Name is not case sensitive. Any registered algorithm with the same name
+	 * will be substituted
+	 *
+	 * @param name
+	 *            of the algorithm
+	 * @param alg
+	 *            algorithm instance to register
+	 */
+	public static synchronized void registerHashAlgorithm(
+			String name, HashAlgorithm alg) {
+		if (name != null) {
+			REGISTRY.put(name.toLowerCase(), alg);
+		}
+	}
+
+	/**
+	 * Tries to find selected hash algorithm using name provided
+	 *
+	 * <p>
+	 * Note, that lookup is being performed using name's lower-case value
+	 *
+	 * @param name
+	 *            the algorithm name to be used for lookup
+	 * @return a {@link HashAlgorithm} instance or <code>null</code> if there's
+	 *         no algorithm with the specified name
+	 */
+	public static synchronized HashAlgorithm lookupHashAlgorithm(String name) {
+		return name == null ? null : REGISTRY.get(name.toLowerCase());
+	}
+}

--- a/src/main/java/net/spy/memcached/KetamaConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/KetamaConnectionFactory.java
@@ -25,7 +25,7 @@ public class KetamaConnectionFactory extends DefaultConnectionFactory {
 	 */
 	public KetamaConnectionFactory(int qLen, int bufSize,
 			long opQueueMaxBlockTime) {
-		super(qLen, bufSize, HashAlgorithm.KETAMA_HASH);
+		super(qLen, bufSize, DefaultHashAlgorithm.KETAMA_HASH);
 	}
 
 	/**

--- a/src/main/java/net/spy/memcached/KetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/KetamaNodeLocator.java
@@ -144,9 +144,9 @@ public final class KetamaNodeLocator extends SpyObject implements NodeLocator {
 	int numReps= config.getNodeRepetitions();
 	for(MemcachedNode node : nodes) {
 		// Ketama does some special work with md5 where it reuses chunks.
-		if(hashAlg == HashAlgorithm.KETAMA_HASH) {
+		if(hashAlg == DefaultHashAlgorithm.KETAMA_HASH) {
 			for(int i=0; i<numReps / 4; i++) {
-				byte[] digest=HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
+				byte[] digest=DefaultHashAlgorithm.computeMd5(config.getKeyForNode(node, i));
 				for(int h=0;h<4;h++) {
 					Long k = ((long)(digest[3+h*4]&0xFF) << 24)
 						| ((long)(digest[2+h*4]&0xFF) << 16)

--- a/src/main/java/net/spy/memcached/MembaseConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/MembaseConnectionFactory.java
@@ -38,7 +38,7 @@ public class MembaseConnectionFactory extends BinaryConnectionFactory {
 	/**
 	 * Default hash algorithm.
 	 */
-	public static final HashAlgorithm DEFAULT_HASH = HashAlgorithm.KETAMA_HASH;
+	public static final HashAlgorithm DEFAULT_HASH = DefaultHashAlgorithm.KETAMA_HASH;
 
 	/**
 	 * Maximum length of the operation queue returned by this connection

--- a/src/main/java/net/spy/memcached/TapConnectionProvider.java
+++ b/src/main/java/net/spy/memcached/TapConnectionProvider.java
@@ -128,13 +128,13 @@ public class TapConnectionProvider extends SpyObject implements ConnectionObserv
 		if (config.getConfigType() == ConfigType.MEMBASE) {
 			cfb.setFailureMode(FailureMode.Retry)
 					.setProtocol(ConnectionFactoryBuilder.Protocol.BINARY)
-					.setHashAlg(HashAlgorithm.KETAMA_HASH)
+					.setHashAlg(config.getHashAlgorithm())
 					.setLocatorType(ConnectionFactoryBuilder.Locator.VBUCKET)
 					.setVBucketConfig(bucket.getConfig());
 		} else if (config.getConfigType() == ConfigType.MEMCACHE) {
 			cfb.setFailureMode(FailureMode.Redistribute)
 					.setProtocol(ConnectionFactoryBuilder.Protocol.BINARY)
-					.setHashAlg(HashAlgorithm.KETAMA_HASH)
+					.setHashAlg(config.getHashAlgorithm())
 					.setLocatorType(ConnectionFactoryBuilder.Locator.CONSISTENT)
 					.setShouldOptimize(false);
 		} else {

--- a/src/main/java/net/spy/memcached/vbucket/config/CacheConfig.java
+++ b/src/main/java/net/spy/memcached/vbucket/config/CacheConfig.java
@@ -1,12 +1,13 @@
 package net.spy.memcached.vbucket.config;
 
+import net.spy.memcached.DefaultHashAlgorithm;
 import net.spy.memcached.HashAlgorithm;
 
 import java.util.List;
 
 public class CacheConfig implements Config {
 
-    private final HashAlgorithm hashAlgorithm = HashAlgorithm.NATIVE_HASH;
+    private final HashAlgorithm hashAlgorithm = DefaultHashAlgorithm.NATIVE_HASH;
 
     private int vbucketsCount;
 

--- a/src/main/java/net/spy/memcached/vbucket/config/DefaultConfigFactory.java
+++ b/src/main/java/net/spy/memcached/vbucket/config/DefaultConfigFactory.java
@@ -13,6 +13,7 @@ import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 
 import net.spy.memcached.HashAlgorithm;
+import net.spy.memcached.HashAlgorithmRegistry;
 
 public class DefaultConfigFactory implements ConfigFactory {
 
@@ -58,27 +59,7 @@ public class DefaultConfigFactory implements ConfigFactory {
         }
     }
 
-    private HashAlgorithm lookupHashAlgorithm(String algorithm) {
-        HashAlgorithm ha = HashAlgorithm.NATIVE_HASH;
-        if ("crc".equalsIgnoreCase(algorithm)) {
-            ha = HashAlgorithm.CRC32_HASH;
-        } else if ("fnv1_32".equalsIgnoreCase(algorithm)) {
-            ha = HashAlgorithm.FNV1_32_HASH;
-        } else if ("fnv1_64".equalsIgnoreCase(algorithm)) {
-            ha = HashAlgorithm.FNV1_64_HASH;
-        } else if ("fnv1a_32".equalsIgnoreCase(algorithm)) {
-            ha = HashAlgorithm.FNV1A_32_HASH;
-        } else if ("fnv1a_64".equalsIgnoreCase(algorithm)) {
-            ha = HashAlgorithm.FNV1A_64_HASH;
-        } else if ("md5".equalsIgnoreCase(algorithm)) {
-            ha = HashAlgorithm.KETAMA_HASH;
-        } else {
-            throw new IllegalArgumentException("Unhandled algorithm type: "
-                    + algorithm);
-        }
-        return ha;
-    }
-
+ 
     private Config parseJSON(JSONObject jsonObject) throws JSONException {
 	// the incoming config could be cache or EP object types, JSON envelope picked apart
 	if (!jsonObject.has("vBucketServerMap" )) {
@@ -103,8 +84,13 @@ public class DefaultConfigFactory implements ConfigFactory {
 
 	/* ep is for ep-engine, a.k.a. membase */
     private Config parseEpJSON(JSONObject jsonObject) throws JSONException {
-
-        HashAlgorithm hashAlgorithm = lookupHashAlgorithm(jsonObject.getString("hashAlgorithm"));
+        String algorithm = jsonObject.getString("hashAlgorithm");
+        HashAlgorithm hashAlgorithm = 
+          HashAlgorithmRegistry.lookupHashAlgorithm(algorithm);
+        if (hashAlgorithm == null){
+			throw new IllegalArgumentException(
+					"Unhandled algorithm type: " + algorithm);
+        }
         int replicasCount = jsonObject.getInt("numReplicas");
         if (replicasCount > VBucket.MAX_REPLICAS) {
             throw new ConfigParsingException("Expected number <= "

--- a/src/test/java/net/spy/memcached/ArrayModNodeLocatorTest.java
+++ b/src/test/java/net/spy/memcached/ArrayModNodeLocatorTest.java
@@ -12,7 +12,7 @@ public class ArrayModNodeLocatorTest extends AbstractNodeLocationCase {
 	protected void setupNodes(int n) {
 		super.setupNodes(n);
 		locator=new ArrayModNodeLocator(Arrays.asList(nodes),
-			HashAlgorithm.NATIVE_HASH);
+			DefaultHashAlgorithm.NATIVE_HASH);
 	}
 
 	public void testPrimary() throws Exception {

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -102,7 +102,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
 		ConnectionFactory f = b.setDaemon(true)
 			.setShouldOptimize(false)
 			.setFailureMode(FailureMode.Redistribute)
-			.setHashAlg(HashAlgorithm.KETAMA_HASH)
+			.setHashAlg(DefaultHashAlgorithm.KETAMA_HASH)
 			.setInitialObservers(Collections.singleton(testObserver))
 			.setOpFact(new BinaryOperationFactory())
 			.setOpTimeout(4225)
@@ -119,7 +119,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
 
 		assertEquals(4225, f.getOperationTimeout());
 		assertEquals(19, f.getReadBufSize());
-		assertSame(HashAlgorithm.KETAMA_HASH, f.getHashAlg());
+		assertSame(DefaultHashAlgorithm.KETAMA_HASH, f.getHashAlg());
 		assertTrue(f.getDefaultTranscoder() instanceof WhalinTranscoder);
 		assertSame(FailureMode.Redistribute, f.getFailureMode());
 		assertEquals(1, f.getInitialObservers().size());

--- a/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
@@ -19,7 +19,7 @@ public class ConnectionFactoryTest extends TestCase {
 
 	public void testBinaryAnIntAnotherIntAndAHashAlgorithmCons() {
 		new BinaryConnectionFactory(5, 5,
-				HashAlgorithm.FNV1_64_HASH);
+				DefaultHashAlgorithm.FNV1_64_HASH);
 	}
 
 	public void testQueueSizes() {

--- a/src/test/java/net/spy/memcached/ConsistentHashingTest.java
+++ b/src/test/java/net/spy/memcached/ConsistentHashingTest.java
@@ -39,9 +39,9 @@ public class ConsistentHashingTest extends TestCase {
 		assertFalse(smaller.contains(oddManOut));
 
 		KetamaNodeLocator lgLocator = new KetamaNodeLocator(
-			larger, HashAlgorithm.KETAMA_HASH);
+			larger, DefaultHashAlgorithm.KETAMA_HASH);
 		KetamaNodeLocator smLocator = new KetamaNodeLocator(
-			smaller, HashAlgorithm.KETAMA_HASH);
+			smaller, DefaultHashAlgorithm.KETAMA_HASH);
 
 		SortedMap<Long, MemcachedNode> lgMap = lgLocator.getKetamaNodes();
 		SortedMap<Long, MemcachedNode> smMap = smLocator.getKetamaNodes();

--- a/src/test/java/net/spy/memcached/DefaultHashAlgorithmTest.java
+++ b/src/test/java/net/spy/memcached/DefaultHashAlgorithmTest.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
 /**
  * Test the hash algorithms.
  */
-public class HashAlgorithmTest extends TestCase {
+public class DefaultHashAlgorithmTest extends TestCase {
 
 	private void assertHash(HashAlgorithm ha, String key, long exp) {
 		assertTrue(exp >= 0L);
@@ -19,7 +19,7 @@ public class HashAlgorithmTest extends TestCase {
 
 	// I don't hardcode any values here because they're subject to change
 	private void assertNativeHash(String key) {
-		assertHash(HashAlgorithm.NATIVE_HASH, key, Math.abs(key.hashCode()));
+		assertHash(DefaultHashAlgorithm.NATIVE_HASH, key, Math.abs(key.hashCode()));
 	}
 
 	public void testNativeHash() {
@@ -37,7 +37,7 @@ public class HashAlgorithmTest extends TestCase {
 		exp.put("UDATA:edevil@sapo.pt", 558L);
 
 		for (Map.Entry<String, Long> me : exp.entrySet()) {
-			assertHash(HashAlgorithm.CRC32_HASH, me.getKey(), me.getValue());
+			assertHash(DefaultHashAlgorithm.CRC32_HASH, me.getKey(), me.getValue());
 		}
 	}
 
@@ -52,7 +52,7 @@ public class HashAlgorithmTest extends TestCase {
 		exp.put("wd:com.google ", 0x12f03d48L);
 
 		for (Map.Entry<String, Long> me : exp.entrySet()) {
-			assertHash(HashAlgorithm.FNV1_64_HASH, me.getKey(),
+			assertHash(DefaultHashAlgorithm.FNV1_64_HASH, me.getKey(),
 				Math.abs(me.getValue()));
 		}
 	}
@@ -69,7 +69,7 @@ public class HashAlgorithmTest extends TestCase {
 		exp.put("wd:com.google ", 0x1c6c1732L);
 
 		for (Map.Entry<String, Long> me : exp.entrySet()) {
-			assertHash(HashAlgorithm.FNV1A_64_HASH, me.getKey(),
+			assertHash(DefaultHashAlgorithm.FNV1A_64_HASH, me.getKey(),
 				Math.abs(me.getValue()));
 		}
 	}
@@ -85,7 +85,7 @@ public class HashAlgorithmTest extends TestCase {
 		exp.put("wd:com.google ", 0x2b0ffd48L);
 
 		for (Map.Entry<String, Long> me : exp.entrySet()) {
-			assertHash(HashAlgorithm.FNV1_32_HASH, me.getKey(),
+			assertHash(DefaultHashAlgorithm.FNV1_32_HASH, me.getKey(),
 				Math.abs(me.getValue()));
 		}
 	}
@@ -101,7 +101,7 @@ public class HashAlgorithmTest extends TestCase {
 		exp.put("wd:com.google ", 0x683e1e12L);
 
 		for (Map.Entry<String, Long> me : exp.entrySet()) {
-			assertHash(HashAlgorithm.FNV1A_32_HASH, me.getKey(),
+			assertHash(DefaultHashAlgorithm.FNV1A_32_HASH, me.getKey(),
 				Math.abs(me.getValue()));
 		}
 	}
@@ -118,7 +118,7 @@ public class HashAlgorithmTest extends TestCase {
 		exp.put("355107", 3611074310L);
 
 		for (Map.Entry<String, Long> me : exp.entrySet()) {
-			assertHash(HashAlgorithm.KETAMA_HASH, me.getKey(),
+			assertHash(DefaultHashAlgorithm.KETAMA_HASH, me.getKey(),
 				Math.abs(me.getValue()));
 		}
 	}

--- a/src/test/java/net/spy/memcached/KetamaConnectionFactoryTest.java
+++ b/src/test/java/net/spy/memcached/KetamaConnectionFactoryTest.java
@@ -20,6 +20,6 @@ public class KetamaConnectionFactoryTest extends TestCase {
 		NodeLocator locator = factory.createLocator(new ArrayList<MemcachedNode>());
 		assertTrue(locator instanceof KetamaNodeLocator);
 
-		assertEquals(HashAlgorithm.KETAMA_HASH, factory.getHashAlg());
+		assertEquals(DefaultHashAlgorithm.KETAMA_HASH, factory.getHashAlg());
 	}
 }

--- a/src/test/java/net/spy/memcached/KetamaNodeLocatorTest.java
+++ b/src/test/java/net/spy/memcached/KetamaNodeLocatorTest.java
@@ -24,7 +24,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
 
 	@Override
 	protected void setupNodes(int n) {
-		setupNodes(HashAlgorithm.KETAMA_HASH, n);
+		setupNodes(DefaultHashAlgorithm.KETAMA_HASH, n);
 	}
 
 	public void testAll() throws Exception {
@@ -116,7 +116,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
 	}
 
 	public void testFNV1A_32() {
-		HashAlgorithm alg=HashAlgorithm.FNV1A_32_HASH;
+		HashAlgorithm alg=DefaultHashAlgorithm.FNV1A_32_HASH;
 		setupNodes(alg, 5);
 		assertSequence("noelani", 1, 2, 2, 2, 3, 4, 2);
 
@@ -150,7 +150,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
 				"10.0.1.7:11211",
 				"10.0.1.8:11211"};
 		locator=new KetamaNodeLocator(Arrays.asList(mockNodes(servers)),
-				HashAlgorithm.KETAMA_HASH);
+				DefaultHashAlgorithm.KETAMA_HASH);
 
 		String[][] exp = {
 				{"0", "10.0.1.1:11211"},

--- a/src/test/java/net/spy/memcached/spring/MemcachedClientFactoryBeanTest.java
+++ b/src/test/java/net/spy/memcached/spring/MemcachedClientFactoryBeanTest.java
@@ -2,9 +2,10 @@ package net.spy.memcached.spring;
 
 import junit.framework.Assert;
 import junit.framework.TestCase;
+
 import net.spy.memcached.ConnectionFactoryBuilder.Protocol;
+import net.spy.memcached.DefaultHashAlgorithm;
 import net.spy.memcached.FailureMode;
-import net.spy.memcached.HashAlgorithm;
 import net.spy.memcached.MemcachedClient;
 import net.spy.memcached.TestConfig;
 import net.spy.memcached.transcoders.SerializingTranscoder;
@@ -24,7 +25,7 @@ public class MemcachedClientFactoryBeanTest extends TestCase {
     final MemcachedClientFactoryBean factory = new MemcachedClientFactoryBean();
     factory.setDaemon(true);
     factory.setFailureMode(FailureMode.Cancel);
-    factory.setHashAlg(HashAlgorithm.CRC32_HASH);
+    factory.setHashAlg(DefaultHashAlgorithm.CRC32_HASH);
     factory.setProtocol(Protocol.BINARY);
     factory.setServers(TestConfig.IPV4_ADDR + ":22211 " + TestConfig.IPV4_ADDR + ":22212");
     factory.setShouldOptimize(true);

--- a/src/test/java/net/spy/memcached/vbucket/config/ConfigurationParserMock.java
+++ b/src/test/java/net/spy/memcached/vbucket/config/ConfigurationParserMock.java
@@ -1,14 +1,14 @@
 package net.spy.memcached.vbucket.config;
 
-import net.spy.memcached.HashAlgorithm;
+import net.spy.memcached.DefaultHashAlgorithm;
 
-import java.util.Map;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Collections;
-import java.text.ParseException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ConfigurationParserMock implements ConfigurationParser {
     private boolean parseBaseCalled = false;
@@ -19,7 +19,7 @@ public class ConfigurationParserMock implements ConfigurationParser {
     private String poolUri = "/pools/default";
     private String poolStreamingUri = "/poolsStreaming/default";
     private String bucketName = "Administrator";
-    private DefaultConfig vbuckets = new DefaultConfig(HashAlgorithm.NATIVE_HASH, 1, 1, 1, null, null);
+    private DefaultConfig vbuckets = new DefaultConfig(DefaultHashAlgorithm.NATIVE_HASH, 1, 1, 1, null, null);
     private String bucketsUri = "/pools/default/buckets";
     private String bucketStreamingUri = "/pools/default/bucketsStreaming/Administrator";
     private List<Node> nodes = Collections.singletonList(


### PR DESCRIPTION
I'm migrating to SpyMemcached from python-memcached on one Jython project and I faced with an issue of setting a custom hash function for the client. We used some tricky one on our former python implementation and I want old python clients to compatible with new Jython ones - we will be sharing memcached cluster with  both former and new clients.

So these changes worked for me and I thought it would be nice to share them. 
Please, let me know what do you think.

Thank you.

Paul.
