### PR TITLE
Add compatibility with netty 3.2.0+

### DIFF
--- a/src/main/java/net/spy/memcached/vbucket/BucketMonitor.java
+++ b/src/main/java/net/spy/memcached/vbucket/BucketMonitor.java
@@ -109,8 +109,8 @@ public class BucketMonitor extends Observable {
    * on the netty HttpHeader class, either setHeader(String, Object) or
    * setHeader(String, String). This indirection is needed as with netty 3.2.0
    * setHeader(String, String) was changed to setHeader(String, Object) and
-   * spymemcached users shall be saved from incompatibilities due to an upgrade to
-   * the newer netty version. Once netty is upgraded to 3.2.0+ this may strategy
+   * spymemcached users shall be saved from incompatibilities due to an upgrade
+   * to the newer netty version. Once netty is upgraded to 3.2.0+ this strategy
    * can be replaced with a direct invocation of setHeader.
    */
   private static final class HttpMessageHeaders {
@@ -127,14 +127,19 @@ public class BucketMonitor extends Observable {
 
     private static Method getHttpMessageHeaderStrategy() {
       try {
-        return HttpRequest.class.getMethod("setHeader", String.class, Object.class);
+        return HttpRequest.class.getMethod("setHeader", String.class,
+            Object.class);
       } catch (final SecurityException e) {
-        throw new RuntimeException("Cannot check method due to security restrictions.", e);
+        throw new RuntimeException("Cannot check method due to security"
+            + " restrictions.", e);
       } catch (final NoSuchMethodException e) {
         try {
-          return HttpRequest.class.getMethod("setHeader", String.class, String.class);
+          return HttpRequest.class.getMethod("setHeader", String.class,
+              String.class);
         } catch (final Exception e1) {
-          throw new RuntimeException("No suitable setHeader method found on netty HttpRequest, the signature seems to have changed.", e1);
+          throw new RuntimeException("No suitable setHeader method found"
+              + " on netty HttpRequest, the signature seems to have changed.",
+              e1);
         }
       }
     }
@@ -143,7 +148,8 @@ public class BucketMonitor extends Observable {
       try {
         m.invoke(obj, name, value);
       } catch (final Exception e) {
-        throw new RuntimeException("Could not invoke method " + m + " with args '" + name + "' and '" + value + "'.", e);
+        throw new RuntimeException("Could not invoke method " + m
+            + " with args '" + name + "' and '" + value + "'.", e);
       }
     }
 
@@ -206,21 +212,23 @@ public class BucketMonitor extends Observable {
         basicAuthHeader =
             ConfigurationProviderHTTP.buildAuthHeader(getHttpUser(),
             getHttpPass());
-        headers.setHeader(request, HttpHeaders.Names.AUTHORIZATION, basicAuthHeader);
+        headers.setHeader(request, HttpHeaders.Names.AUTHORIZATION,
+            basicAuthHeader);
       } catch (UnsupportedEncodingException ex) {
         throw new RuntimeException("Could not encode specified credentials"
             + " for HTTP request.", ex);
       }
     }
     // No keep-alives for this
-    headers.setHeader(request, HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE);
+    headers.setHeader(request, HttpHeaders.Names.CONNECTION,
+        HttpHeaders.Values.CLOSE);
     headers.setHeader(request, HttpHeaders.Names.CACHE_CONTROL,
         HttpHeaders.Values.NO_CACHE);
     headers.setHeader(request, HttpHeaders.Names.ACCEPT, "application/json");
     headers.setHeader(request, HttpHeaders.Names.USER_AGENT,
         "spymemcached vbucket client");
-    headers.setHeader(request, "X-memcachekv-Store-Client-Specification-Version",
-        CLIENT_SPEC_VER);
+    headers.setHeader(request, "X-memcachekv-Store-Client-Specification-"
+        + "Version", CLIENT_SPEC_VER);
     return request;
   }
 


### PR DESCRIPTION
Netty 3.2.0+ (NETTY-281) changed HttpMessage.setHeader(String, String) to setHeader(String, Object), which causes NoSuchMethodErrors when spymemcached is used with such a newer netty version. To prevent spymemcached users from other library incompatibilities the netty dependency is not upgraded, but the appropriate setHeader method is selected and invoked at runtime (via reflection). This was discussed on the mailing list: http://groups.google.com/group/spymemcached/browse_thread/thread/4b9f0638bbcc96fb
