### PR TITLE
A fix for CAS mutations changing expirations to 0

### DIFF
--- a/src/main/java/net/spy/memcached/CASMutator.java
+++ b/src/main/java/net/spy/memcached/CASMutator.java
@@ -94,11 +94,11 @@ public class CASMutator<T> extends SpyObject {
    *
    * @param key the key to be CASed
    * @param initial the value to use when the object is not cached
-   * @param initialExp the expiration time to use when initializing
+   * @param exp the expiration time to use
    * @param m the mutation to perform on an object if a value exists for the key
    * @return the new value that was set
    */
-  public T cas(final String key, final T initial, int initialExp,
+  public T cas(final String key, final T initial, int exp,
       final CASMutation<T> m) throws Exception {
     T rv = initial;
 
@@ -126,7 +126,7 @@ public class CASMutator<T> extends SpyObject {
         // behavior will be fine in this code -- we'll do another gets
         // and follow it up with either an add or another cas depending
         // on whether it exists the next time.
-        if (client.cas(key, casval.getCas(), rv, transcoder)
+        if (client.cas(key, casval.getCas(), exp, rv, transcoder)
             == CASResponse.OK) {
           done = true;
         }
@@ -135,7 +135,7 @@ public class CASMutator<T> extends SpyObject {
         if (initial == null) {
           done = true;
           rv = null;
-        } else if (client.add(key, initialExp, initial, transcoder).get()) {
+        } else if (client.add(key, exp, initial, transcoder).get()) {
           done = true;
           rv = initial;
         }


### PR DESCRIPTION
This is related to issue 184. Any CAS mutations after the initial add result in the key's expiration time being set to zero (never expire). I simply changed it so the expiration passed to CASmutator.cas is also passed to MemcachedClient.cas.
