### PR TITLE
Added getLocalStats to MemcachedClient 

### DIFF
--- a/src/main/java/net/spy/memcached/LocalStatType.java
+++ b/src/main/java/net/spy/memcached/LocalStatType.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2012 Usman Ismail
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
+
+package net.spy.memcached;
+public enum LocalStatType {
+	WRITE_QUEUE_SIZE, READ_QUEUE_SIZE, INPUT_QUEUE_SIZE,
+}

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -37,6 +37,7 @@ import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -48,6 +49,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 
+import net.spy.memcached.LocalStatType;
 import net.spy.memcached.compat.SpyThread;
 import net.spy.memcached.compat.log.LoggerFactory;
 import net.spy.memcached.ops.KeyedOperation;
@@ -853,4 +855,19 @@ public class MemcachedConnection extends SpyThread {
       getLogger().warn("Problem handling memcached IO", e);
     }
   }
+  
+  /**
+   * Get all of the local stats from all of the connections. This will not 
+   * send a call to server but report only stats that are known to client.
+   *
+   * @return a Map of a Map of stats by SocketAddress
+   */
+  public Map<SocketAddress, Map<LocalStatType, String>> getLocalStats() {
+    Map<SocketAddress, Map <LocalStatType, String>> localStatMaps;
+    localStatMaps = new HashMap<SocketAddress, Map <LocalStatType, String>>();
+    for (MemcachedNode node : locator.getAll()) {
+      localStatMaps.put(node.getSocketAddress(), node.getLocalStats());
+    }
+    return localStatMaps;
+  }	
 }

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -29,7 +29,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
+import java.util.Map;
 
+import net.spy.memcached.LocalStatType;
 import net.spy.memcached.ops.Operation;
 
 /**
@@ -220,4 +222,11 @@ public interface MemcachedNode {
   void setContinuousTimeout(boolean timedOut);
 
   int getContinuousTimeout();
+  
+  /**
+   * Get all local stats for this node grouped by Stat ID
+   *
+   * @return a Map of stats by Stat ID
+   */
+  Map<LocalStatType, String> getLocalStats();
 }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -34,7 +34,11 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Map;
+import java.util.HashMap;
 
+
+import net.spy.memcached.LocalStatType;
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.ops.Operation;
@@ -604,5 +608,15 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     } else {
       authLatch = new CountDownLatch(0);
     }
+  }
+  
+  public Map<LocalStatType, String> getLocalStats(){
+    Map <LocalStatType, String> localStatMap;
+    localStatMap = new HashMap<LocalStatType, String>();
+    localStatMap.put(LocalStatType.WRITE_QUEUE_SIZE, String.valueOf(writeQ.size()));
+    localStatMap.put(LocalStatType.READ_QUEUE_SIZE, String.valueOf(readQ.size()));
+    localStatMap.put(LocalStatType.INPUT_QUEUE_SIZE, String.valueOf(inputQueue.size()));
+    
+    return localStatMap;
   }
 }


### PR DESCRIPTION
Added getLocalStats to MemcachedClient to report stats about each connection that are available client side. Currently the only stats are the sizes of the three internal queues. These are useful for us as under load we start to get timeouts even though our servers are not overloaded. We want to see if the client is throwing these exceptions because the client side queues are overloaded.
