### PR TITLE
Add a Simple Twemproxy compatible KetamaNodeLocatorConfiguration support...

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -34,6 +34,7 @@ import net.spy.memcached.ops.OperationQueueFactory;
 import net.spy.memcached.protocol.ascii.AsciiOperationFactory;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 import net.spy.memcached.transcoders.Transcoder;
+import net.spy.memcached.util.KetamaNodeLocatorConfiguration;
 
 /**
  * Builder for more easily configuring a ConnectionFactory.
@@ -68,6 +69,8 @@ public class ConnectionFactoryBuilder {
 
   protected int timeoutExceptionThreshold =
       DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD;
+
+  protected KetamaNodeLocatorConfiguration nodeLocatorConf = null;
 
   /**
    * Set the operation queue factory.
@@ -264,6 +267,12 @@ public class ConnectionFactoryBuilder {
     return this;
   }
 
+  public ConnectionFactoryBuilder setKetamaNodeLocatorConfiguration(KetamaNodeLocatorConfiguration conf) {
+      assert conf != null;
+      nodeLocatorConf = conf;
+      return this;
+  }
+
   /**
    * Get the ConnectionFactory set up with the provided parameters.
    */
@@ -294,7 +303,11 @@ public class ConnectionFactoryBuilder {
         case ARRAY_MOD:
           return new ArrayModNodeLocator(nodes, getHashAlg());
         case CONSISTENT:
-          return new KetamaNodeLocator(nodes, getHashAlg());
+          if (nodeLocatorConf == null) {
+            return new KetamaNodeLocator(nodes, getHashAlg());
+          } else {
+            return new KetamaNodeLocator(nodes, getHashAlg(), nodeLocatorConf);
+          }
         default:
           throw new IllegalStateException("Unhandled locator type: " + locator);
         }

--- a/src/main/java/net/spy/memcached/util/twemproxy/SimpleTwemproxyNodeLocatorConfiguration.java
+++ b/src/main/java/net/spy/memcached/util/twemproxy/SimpleTwemproxyNodeLocatorConfiguration.java
@@ -1,0 +1,58 @@
+package net.spy.memcached.util.twemproxy;
+
+import net.spy.memcached.MemcachedNode;
+import net.spy.memcached.util.KetamaNodeLocatorConfiguration;
+
+import java.net.SocketAddress;
+import java.util.HashMap;
+
+/**
+ * Simple implementation of Twemproxy compatible node locator configuration.
+ *
+ * Twemproxy differs from the default spymemcached configuration by only using the server
+ * hostname and not the hostname and port number for building the continuum hash points.
+ *
+ * The client must provide a mapping between SocketAddresses and hostname as specified in the
+ * Twemproxy configuration file for the the host pool.  In the Twemproxy configuration file,
+ * hosts are specified as host:port:weight, only the host portion should be used and it must
+ * be specified exactly as in the Twemproxy conf file.  All hosts must be weighted equally.
+ *
+ * @author Tague Griffith
+ */
+public class SimpleTwemproxyNodeLocatorConfiguration implements KetamaNodeLocatorConfiguration
+{
+    protected static final int KETAMA_POINTS_PER_SERVER = 160;
+    protected HashMap<SocketAddress,String> hostCache;
+
+    public SimpleTwemproxyNodeLocatorConfiguration(HashMap<SocketAddress, String> hostMap) {
+
+        // build a copy of the host cache
+        hostCache = new HashMap<SocketAddress, String>(hostMap);
+    }
+
+    /**
+     * Returns a uniquely identifying key, suitable for hashing by the
+     * KetamaNodeLocator algorithm.
+     *
+     * @param node       The MemcachedNode to use to form the unique identifier
+     * @param repetition The repetition number for the particular node in question
+     *                   (0 is the first repetition)
+     * @return The key that represents the specific repetition of the node
+     */
+    @Override
+    public String getKeyForNode(MemcachedNode node, int repetition) {
+        return hostCache.get(node.getSocketAddress()) + "-" + repetition;
+    }
+
+    /**
+     * Returns the number of discrete hashes that should be defined for each node
+     * in the continuum.
+     *
+     * @return a value greater than 0
+     */
+    @Override
+    public int getNodeRepetitions() {
+        return KETAMA_POINTS_PER_SERVER;
+    }
+
+}

--- a/src/test/java/net/spy/memcached/util/twemproxy/SimpleTwemproxyNodeLocatorTest.java
+++ b/src/test/java/net/spy/memcached/util/twemproxy/SimpleTwemproxyNodeLocatorTest.java
@@ -1,0 +1,46 @@
+package net.spy.memcached.util.twemproxy;
+
+import net.spy.memcached.MemcachedNode;
+import net.spy.memcached.compat.BaseMockCase;
+import net.spy.memcached.util.twemproxy.SimpleTwemproxyNodeLocatorConfiguration;
+import org.jmock.Mock;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.HashMap;
+
+public class SimpleTwemproxyNodeLocatorTest extends BaseMockCase
+{
+    SimpleTwemproxyNodeLocatorConfiguration nodeLocator;
+    HashMap<SocketAddress, String> hostMap;
+
+    public void setUp() {
+        hostMap = new HashMap<SocketAddress, String>();
+        hostMap.put(new InetSocketAddress("10.0.10.1", 11211), "10.0.10.1");
+        hostMap.put(new InetSocketAddress("10.0.10.2", 11211), "10.0.10.2");
+        hostMap.put(new InetSocketAddress("10.0.10.3", 11211), "10.0.10.3");
+        hostMap.put(new InetSocketAddress("10.0.10.4", 11211), "10.0.10.4");
+
+        nodeLocator = new SimpleTwemproxyNodeLocatorConfiguration(hostMap);
+
+    }
+
+    public void tearDown() {
+        // empty
+    }
+
+    @Test
+    public void testNodeRepetitions() {
+        assertEquals(nodeLocator.getNodeRepetitions(), 160);
+    }
+
+    @Test
+    public void testGetKeyForNode() {
+
+        Mock m = mock(MemcachedNode.class);
+        m.expects(once()).method("getSocketAddress").withNoArguments()
+          .will(returnValue(new InetSocketAddress("10.0.10.1", 11211)));
+        assertEquals(nodeLocator.getKeyForNode((MemcachedNode) m.proxy(), 4), "10.0.10.1-4");
+    }
+}


### PR DESCRIPTION
...ing uniform weighting.

I've created a utility KetamaNodeLocatorConfiguration that is compatible with the Twemproxy implementation of Ketama in nc_ketama.c provided that the servers are weighted uniformly.  The patch also modifies the ConnectionFactoryBuilder to expose a method for a client to set an alternative configuration object on the Ketama locator object. 
