### PR TITLE
add javadoc about default compression threshold

### DIFF
--- a/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
@@ -29,6 +29,7 @@ import net.spy.memcached.util.StringUtils;
 
 /**
  * Transcoder that serializes and compresses objects.
+ * <p>NOTE: The transcoder compression threshold is set by default to {@Link BaseSerializingTranscoder.DEFAULT_COMPRESSION_THRESHOLD} - 16384 bytes.
  */
 public class SerializingTranscoder extends BaseSerializingTranscoder implements
     Transcoder<Object> {


### PR DESCRIPTION
Hi Dustin,
I was struggling about 2 days to find out the issue with compressed image content which could not be served by nginx memcached anent (broken image).

I hope this little JavaDoc will help people to manage such situations 
