### PR TITLE
+ reduce memory use of GETs when using binary protocol

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -222,37 +222,38 @@ public  abstract class OperationImpl extends BaseOperationImpl
    */
   protected OperationStatus getStatusForErrorCode(int errCode, byte[] errPl)
     throws IOException {
-    errorMsg = new byte[errPl.length];
-    errorMsg = errPl.clone();
 
-    StatusCode statusCode = StatusCode.fromBinaryCode(errCode);
+    if(errCode == SUCCESS) {
+        return STATUS_OK;
+    } else {
+        StatusCode statusCode = StatusCode.fromBinaryCode(errCode);
+        errorMsg = errPl.clone();
 
-    switch (errCode) {
-    case SUCCESS:
-      return STATUS_OK;
-    case ERR_NOT_FOUND:
-      return new CASOperationStatus(false, new String(errPl),
-          CASResponse.NOT_FOUND, statusCode);
-    case ERR_EXISTS:
-      return new CASOperationStatus(false, new String(errPl),
-          CASResponse.EXISTS, statusCode);
-    case ERR_NOT_STORED:
-      return new CASOperationStatus(false, new String(errPl),
-          CASResponse.NOT_FOUND, statusCode);
-    case ERR_2BIG:
-    case ERR_INTERNAL:
-      handleError(OperationErrorType.SERVER, new String(errPl));
-    case ERR_INVAL:
-    case ERR_DELTA_BADVAL:
-    case ERR_NOT_MY_VBUCKET:
-    case ERR_UNKNOWN_COMMAND:
-    case ERR_NO_MEM:
-    case ERR_NOT_SUPPORTED:
-    case ERR_BUSY:
-    case ERR_TEMP_FAIL:
-      return new OperationStatus(false, new String(errPl), statusCode);
-    default:
-      return null;
+        switch (errCode) {
+            case ERR_NOT_FOUND:
+                return new CASOperationStatus(false, new String(errPl),
+                        CASResponse.NOT_FOUND, statusCode);
+            case ERR_EXISTS:
+                return new CASOperationStatus(false, new String(errPl),
+                        CASResponse.EXISTS, statusCode);
+            case ERR_NOT_STORED:
+                return new CASOperationStatus(false, new String(errPl),
+                        CASResponse.NOT_FOUND, statusCode);
+            case ERR_2BIG:
+            case ERR_INTERNAL:
+                handleError(OperationErrorType.SERVER, new String(errPl));
+            case ERR_INVAL:
+            case ERR_DELTA_BADVAL:
+            case ERR_NOT_MY_VBUCKET:
+            case ERR_UNKNOWN_COMMAND:
+            case ERR_NO_MEM:
+            case ERR_NOT_SUPPORTED:
+            case ERR_BUSY:
+            case ERR_TEMP_FAIL:
+                return new OperationStatus(false, new String(errPl), statusCode);
+            default:
+                return null;
+        }
     }
   }
 


### PR DESCRIPTION
Hi,

I noticed that a byte[] array of the size of the content fetched from memcached is created for every GET that is successful, in order to represent a errorMsg.  This results in a lot of memory allocations, that are subsequently not used.

This PR removes the byte[] allocation in the SUCCESS scenario, removing allocation pressure.  The below screen shots are from a JMC view of a flight recorder profile showing the removal of GB's of allocations from a load test that simulates 760,000 gets for 26k of content stored in memcached.  Removing the allocations, allowed another 70k of requests to be generated by the load test.
- BEFORE
  ![screen shot 2014-05-25 at 13 17 19](https://cloud.githubusercontent.com/assets/211070/3077060/6cf2f512-e410-11e3-968a-ff310b1317ed.png)
- AFTER
  ![screen shot 2014-05-25 at 14 05 23](https://cloud.githubusercontent.com/assets/211070/3077063/78a54018-e410-11e3-8312-7118bb759de7.png)
