### PR TITLE
Updated DefaultLogger to only System.err messages of WARN or higher leve...

### DIFF
--- a/src/main/java/net/spy/memcached/compat/log/DefaultLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/DefaultLogger.java
@@ -73,8 +73,7 @@ public class DefaultLogger extends AbstractLogger {
    */
   @Override
   public synchronized void log(Level level, Object message, Throwable e) {
-    if (level == Level.INFO
-        || level == Level.WARN
+    if (level == Level.WARN
         || level == Level.ERROR
         || level == Level.FATAL) {
       System.err.printf("%s %s %s:  %s\n", df.format(new Date()), level.name(),


### PR DESCRIPTION
...l.  The comments indicated it should not log INFO messages, but it currently does and it causes a lot of errors to be generated for normal behavior.
