### PR TITLE
Late-bind DNS resolutions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.spy</groupId>
     <artifactId>spymemcached</artifactId>
-    <version>2.999.999-SNAPSHOT</version> <!-- not used -->
+    <version>2.11.4-tellapart</version> <!-- not used -->
 
     <name>Spymemcached</name>
     <description>A client library for memcached.</description>

--- a/src/main/java/net/spy/memcached/AddrUtil.java
+++ b/src/main/java/net/spy/memcached/AddrUtil.java
@@ -23,7 +23,6 @@
 
 package net.spy.memcached;
 
-import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,14 +44,14 @@ public final class AddrUtil {
    *
    * Note that colon-delimited IPv6 is also supported. For example: ::1:11211
    */
-  public static List<InetSocketAddress> getAddresses(String s) {
+  public static List<HostPort> getAddresses(String s) {
     if (s == null) {
       throw new NullPointerException("Null host list");
     }
     if (s.trim().equals("")) {
       throw new IllegalArgumentException("No hosts in list:  ``" + s + "''");
     }
-    ArrayList<InetSocketAddress> addrs = new ArrayList<InetSocketAddress>();
+    ArrayList<HostPort> addrs = new ArrayList<HostPort>();
 
     for (String hoststuff : s.split("(?:\\s|,)+")) {
       if (hoststuff.equals("")) {
@@ -67,15 +66,14 @@ public final class AddrUtil {
       String hostPart = hoststuff.substring(0, finalColon);
       String portNum = hoststuff.substring(finalColon + 1);
 
-      addrs.add(new InetSocketAddress(hostPart, Integer.parseInt(portNum)));
+      addrs.add(new HostPort(hostPart, Integer.parseInt(portNum)));
     }
     assert !addrs.isEmpty() : "No addrs found";
     return addrs;
   }
 
-  public static List<InetSocketAddress> getAddresses(List<String> servers) {
-    ArrayList<InetSocketAddress> addrs =
-        new ArrayList<InetSocketAddress>(servers.size());
+  public static List<HostPort> getAddresses(List<String> servers) {
+    ArrayList<HostPort> addrs = new ArrayList<HostPort>(servers.size());
     for (String server : servers) {
       int finalColon = server.lastIndexOf(':');
       if (finalColon < 1) {
@@ -85,7 +83,7 @@ public final class AddrUtil {
       String hostPart = server.substring(0, finalColon);
       String portNum = server.substring(finalColon + 1);
 
-      addrs.add(new InetSocketAddress(hostPart, Integer.parseInt(portNum)));
+      addrs.add(new HostPort(hostPart, Integer.parseInt(portNum)));
     }
     if (addrs.isEmpty()) {
       // servers was passed in empty, and shouldn't have been
@@ -94,13 +92,12 @@ public final class AddrUtil {
     return addrs;
   }
 
-  public static List<InetSocketAddress>
-  getAddressesFromURL(List<URL> servers) {
-    ArrayList<InetSocketAddress> addrs =
-      new ArrayList<InetSocketAddress>(servers.size());
+  public static List<HostPort> getAddressesFromURL(List<URL> servers) {
+    ArrayList<HostPort> addrs = new ArrayList<HostPort>(servers.size());
     for (URL server : servers) {
-      addrs.add(new InetSocketAddress(server.getHost(), server.getPort()));
+      addrs.add(new HostPort(server.getHost(), server.getPort()));
     }
     return addrs;
   }
+
 }

--- a/src/main/java/net/spy/memcached/BinaryConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/BinaryConnectionFactory.java
@@ -23,7 +23,6 @@
 
 package net.spy.memcached;
 
-import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
 
 import net.spy.memcached.protocol.binary.BinaryMemcachedNodeImpl;
@@ -61,16 +60,23 @@ public class BinaryConnectionFactory extends DefaultConnectionFactory {
   }
 
   @Override
-  public MemcachedNode createMemcachedNode(SocketAddress sa, SocketChannel c,
-      int bufSize) {
+  public MemcachedNode createMemcachedNode(HostPort hp, SocketChannel c, int bufSize) {
     boolean doAuth = false;
     if (getAuthDescriptor() != null) {
         doAuth = true;
     }
-    return new BinaryMemcachedNodeImpl(sa, c, bufSize,
-        createReadOperationQueue(), createWriteOperationQueue(),
-        createOperationQueue(), getOpQueueMaxBlockTime(), doAuth,
-        getOperationTimeout(), getAuthWaitTime(), this);
+    return new BinaryMemcachedNodeImpl(
+        hp,
+        c,
+        bufSize,
+        createReadOperationQueue(),
+        createWriteOperationQueue(),
+        createOperationQueue(),
+        getOpQueueMaxBlockTime(),
+        doAuth,
+        getOperationTimeout(),
+        getAuthWaitTime(),
+        this);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -24,8 +24,6 @@
 package net.spy.memcached;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
 import java.util.List;
@@ -51,14 +49,13 @@ public interface ConnectionFactory {
    * @return a new MemcachedConnection connected to those addresses
    * @throws IOException for problems initializing the memcached connections
    */
-  MemcachedConnection createConnection(List<InetSocketAddress> addrs)
+  MemcachedConnection createConnection(List<HostPort> addrs)
     throws IOException;
 
   /**
    * Create a new memcached node.
    */
-  MemcachedNode createMemcachedNode(SocketAddress sa, SocketChannel c,
-      int bufSize);
+  MemcachedNode createMemcachedNode(HostPort hp, SocketChannel c,int bufSize);
 
   /**
    * Create a BlockingQueue for operations for a connection.

--- a/src/main/java/net/spy/memcached/ConnectionObserver.java
+++ b/src/main/java/net/spy/memcached/ConnectionObserver.java
@@ -22,8 +22,6 @@
 
 package net.spy.memcached;
 
-import java.net.SocketAddress;
-
 /**
  * Users of this interface will be notified when changes to the state of
  * connections take place.
@@ -33,16 +31,16 @@ public interface ConnectionObserver {
   /**
    * A connection has just successfully been established on the given socket.
    *
-   * @param sa the address of the node whose connection was established
+   * @param hp the address of the node whose connection was established
    * @param reconnectCount the number of attempts before the connection was
    *          established
    */
-  void connectionEstablished(SocketAddress sa, int reconnectCount);
+  void connectionEstablished(HostPort hp, int reconnectCount);
 
   /**
    * A connection was just lost on the given socket.
    *
    * @param sa the address of the node whose connection was lost
    */
-  void connectionLost(SocketAddress sa);
+  void connectionLost(HostPort sa);
 }

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -24,8 +24,6 @@
 package net.spy.memcached;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,9 +31,7 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -166,12 +162,14 @@ public class DefaultConnectionFactory extends SpyObject implements
     this(DEFAULT_OP_QUEUE_LEN, DEFAULT_READ_BUFFER_SIZE);
   }
 
-  public MemcachedNode createMemcachedNode(SocketAddress sa, SocketChannel c,
-      int bufSize) {
+  public MemcachedNode createMemcachedNode(HostPort hp, SocketChannel c, int bufSize) {
 
     OperationFactory of = getOperationFactory();
     if (of instanceof AsciiOperationFactory) {
-      return new AsciiMemcachedNodeImpl(sa, c, bufSize,
+      return new AsciiMemcachedNodeImpl(
+          hp,
+          c,
+          bufSize,
           createReadOperationQueue(),
           createWriteOperationQueue(),
           createOperationQueue(),
@@ -184,7 +182,10 @@ public class DefaultConnectionFactory extends SpyObject implements
       if (getAuthDescriptor() != null) {
         doAuth = true;
       }
-      return new BinaryMemcachedNodeImpl(sa, c, bufSize,
+      return new BinaryMemcachedNodeImpl(
+          hp,
+          c,
+          bufSize,
           createReadOperationQueue(),
           createWriteOperationQueue(),
           createOperationQueue(),
@@ -203,7 +204,7 @@ public class DefaultConnectionFactory extends SpyObject implements
    *
    * @see net.spy.memcached.ConnectionFactory#createConnection(java.util.List)
    */
-  public MemcachedConnection createConnection(List<InetSocketAddress> addrs)
+  public MemcachedConnection createConnection(List<HostPort> addrs)
     throws IOException {
     return new MemcachedConnection(getReadBufSize(), this, addrs,
         getInitialObservers(), getFailureMode(), getOperationFactory());

--- a/src/main/java/net/spy/memcached/HostPort.java
+++ b/src/main/java/net/spy/memcached/HostPort.java
@@ -1,0 +1,79 @@
+package net.spy.memcached;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Container for the hostname and port of a Node, and resolve them into an
+ * InetSocketAddress.
+ */
+public class HostPort {
+
+  private final String host;
+  private final int port;
+
+  private volatile InetSocketAddress address;
+
+  public HostPort(String host, int port) {
+    this.host = host;
+    this.port = port;
+  }
+
+  public String getHostName() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  /**
+   * Get the InetSocketAddress. If it has not already been resolved then
+   * resolve it.
+   */
+  public InetSocketAddress getAddress() {
+    if (address == null) {
+      resolveAddress();
+    }
+    return address;
+  }
+
+  /**
+   * Resolve and return the InetSocketAddress. If it has already been resolved,
+   * it will be re-resolved.
+   */
+  public InetSocketAddress resolveAddress() {
+    address = new InetSocketAddress(host, port);
+    return address;
+  }
+
+  @Override
+  public String toString() {
+    if (address == null) {
+      return InetSocketAddress.createUnresolved(host, port).toString();
+    }
+    else {
+      return address.toString();
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    HostPort hostPort = (HostPort) o;
+
+    if (port != hostPort.port) return false;
+    if (host != null ? !host.equals(hostPort.host) : hostPort.host != null) return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = host != null ? host.hashCode() : 0;
+    result = 31 * result + port;
+    return result;
+  }
+
+}

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -24,8 +24,6 @@
 package net.spy.memcached;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -74,7 +72,6 @@ import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.ops.StoreOperation;
 import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.ops.TimedOutOperationStatus;
-import net.spy.memcached.protocol.ascii.AsciiOperationFactory;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 import net.spy.memcached.transcoders.TranscodeService;
 import net.spy.memcached.transcoders.Transcoder;
@@ -166,7 +163,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    * @param ia the memcached locations
    * @throws IOException if connections cannot be established
    */
-  public MemcachedClient(InetSocketAddress... ia) throws IOException {
+  public MemcachedClient(HostPort... ia) throws IOException {
     this(new DefaultConnectionFactory(), Arrays.asList(ia));
   }
 
@@ -176,7 +173,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    * @param addrs the socket addrs
    * @throws IOException if connections cannot be established
    */
-  public MemcachedClient(List<InetSocketAddress> addrs) throws IOException {
+  public MemcachedClient(List<HostPort> addrs) throws IOException {
     this(new DefaultConnectionFactory(), addrs);
   }
 
@@ -187,7 +184,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    * @param addrs the socket addresses
    * @throws IOException if connections cannot be established
    */
-  public MemcachedClient(ConnectionFactory cf, List<InetSocketAddress> addrs)
+  public MemcachedClient(ConnectionFactory cf, List<HostPort> addrs)
     throws IOException {
     if (cf == null) {
       throw new NullPointerException("Connection factory required");
@@ -229,11 +226,11 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    * @return point-in-time view of currently available servers
    */
   @Override
-  public Collection<SocketAddress> getAvailableServers() {
-    ArrayList<SocketAddress> rv = new ArrayList<SocketAddress>();
+  public Collection<HostPort> getAvailableServers() {
+    ArrayList<HostPort> rv = new ArrayList<HostPort>();
     for (MemcachedNode node : mconn.getLocator().getAll()) {
       if (node.isActive()) {
-        rv.add(node.getSocketAddress());
+        rv.add(node.getHostPort());
       }
     }
     return rv;
@@ -251,11 +248,11 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    * @return point-in-time view of currently available servers
    */
   @Override
-  public Collection<SocketAddress> getUnavailableServers() {
-    ArrayList<SocketAddress> rv = new ArrayList<SocketAddress>();
+  public Collection<HostPort> getUnavailableServers() {
+    ArrayList<HostPort> rv = new ArrayList<HostPort>();
     for (MemcachedNode node : mconn.getLocator().getAll()) {
       if (!node.isActive()) {
-        rv.add(node.getSocketAddress());
+        rv.add(node.getHostPort());
       }
     }
     return rv;
@@ -1652,20 +1649,20 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   /**
    * Get the versions of all of the connected memcacheds.
    *
-   * @return a Map of SocketAddress to String for connected servers
+   * @return a Map of HostPort to String for connected servers
    * @throws IllegalStateException in the rare circumstance where queue is too
    *           full to accept any more requests
    */
   @Override
-  public Map<SocketAddress, String> getVersions() {
-    final Map<SocketAddress, String> rv =
-        new ConcurrentHashMap<SocketAddress, String>();
+  public Map<HostPort, String> getVersions() {
+    final Map<HostPort, String> rv =
+        new ConcurrentHashMap<HostPort, String>();
 
     CountDownLatch blatch = broadcastOp(new BroadcastOpFactory() {
       @Override
       public Operation newOp(final MemcachedNode n,
           final CountDownLatch latch) {
-        final SocketAddress sa = n.getSocketAddress();
+        final HostPort sa = n.getHostPort();
         return opFact.version(new OperationCallback() {
           @Override
           public void receivedStatus(OperationStatus s) {
@@ -1690,12 +1687,12 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   /**
    * Get all of the stats from all of the connections.
    *
-   * @return a Map of a Map of stats replies by SocketAddress
+   * @return a Map of a Map of stats replies by HostPort
    * @throws IllegalStateException in the rare circumstance where queue is too
    *           full to accept any more requests
    */
   @Override
-  public Map<SocketAddress, Map<String, String>> getStats() {
+  public Map<HostPort, Map<String, String>> getStats() {
     return getStats(null);
   }
 
@@ -1703,21 +1700,21 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    * Get a set of stats from all connections.
    *
    * @param arg which stats to get
-   * @return a Map of the server SocketAddress to a map of String stat keys to
+   * @return a Map of the server HostPort to a map of String stat keys to
    *         String stat values.
    * @throws IllegalStateException in the rare circumstance where queue is too
    *           full to accept any more requests
    */
   @Override
-  public Map<SocketAddress, Map<String, String>> getStats(final String arg) {
-    final Map<SocketAddress, Map<String, String>> rv =
-        new HashMap<SocketAddress, Map<String, String>>();
+  public Map<HostPort, Map<String, String>> getStats(final String arg) {
+    final Map<HostPort, Map<String, String>> rv =
+        new HashMap<HostPort, Map<String, String>>();
 
     CountDownLatch blatch = broadcastOp(new BroadcastOpFactory() {
       @Override
       public Operation newOp(final MemcachedNode n,
           final CountDownLatch latch) {
-        final SocketAddress sa = n.getSocketAddress();
+        final HostPort sa = n.getHostPort();
         rv.put(sa, new HashMap<String, String>());
         return opFact.stats(arg, new StatsOperation.Callback() {
           @Override
@@ -2575,7 +2572,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     if (rv) {
       for (MemcachedNode node : mconn.getLocator().getAll()) {
         if (node.isActive()) {
-          obs.connectionEstablished(node.getSocketAddress(), -1);
+          obs.connectionEstablished(node.getHostPort(), -1);
         }
       }
     }
@@ -2594,23 +2591,23 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   }
 
   @Override
-  public void connectionEstablished(SocketAddress sa, int reconnectCount) {
+  public void connectionEstablished(HostPort hp, int reconnectCount) {
     if (authDescriptor != null) {
       if (authDescriptor.authThresholdReached()) {
         shutdown();
       }
-      authMonitor.authConnection(mconn, opFact, authDescriptor, findNode(sa));
+      authMonitor.authConnection(mconn, opFact, authDescriptor, findNode(hp));
     }
   }
 
-  private MemcachedNode findNode(SocketAddress sa) {
+  private MemcachedNode findNode(HostPort hp) {
     MemcachedNode node = null;
     for (MemcachedNode n : mconn.getLocator().getAll()) {
-      if (n.getSocketAddress().equals(sa)) {
+      if (n.getHostPort().equals(hp)) {
         node = n;
       }
     }
-    assert node != null : "Couldn't find node connected to " + sa;
+    assert node != null : "Couldn't find node connected to " + hp;
     return node;
   }
 
@@ -2624,7 +2621,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   }
 
   @Override
-  public void connectionLost(SocketAddress sa) {
+  public void connectionLost(HostPort sa) {
     // Don't care.
   }
 

--- a/src/main/java/net/spy/memcached/MemcachedClientIF.java
+++ b/src/main/java/net/spy/memcached/MemcachedClientIF.java
@@ -23,7 +23,6 @@
 
 package net.spy.memcached;
 
-import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -46,9 +45,9 @@ public interface MemcachedClientIF {
    */
   int MAX_KEY_LENGTH = 250;
 
-  Collection<SocketAddress> getAvailableServers();
+  Collection<HostPort> getAvailableServers();
 
-  Collection<SocketAddress> getUnavailableServers();
+  Collection<HostPort> getUnavailableServers();
 
   Transcoder<Object> getTranscoder();
 
@@ -158,11 +157,11 @@ public interface MemcachedClientIF {
 
   <T> Future<Boolean> touch(final String key, final int exp);
 
-  Map<SocketAddress, String> getVersions();
+  Map<HostPort, String> getVersions();
 
-  Map<SocketAddress, Map<String, String>> getStats();
+  Map<HostPort, Map<String, String>> getStats();
 
-  Map<SocketAddress, Map<String, String>> getStats(String prefix);
+  Map<HostPort, Map<String, String>> getStats(String prefix);
 
   long incr(String key, long by);
 

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -24,7 +24,6 @@
 package net.spy.memcached;
 
 import java.io.IOException;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
@@ -132,8 +131,9 @@ public interface MemcachedNode {
 
   /**
    * Get the SocketAddress of the server to which this node is connected.
+   *
    */
-  SocketAddress getSocketAddress();
+  HostPort getHostPort();
 
   /**
    * True if this node is <q>active.</q> i.e. is is currently connected and

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -24,7 +24,6 @@
 package net.spy.memcached;
 
 import java.io.IOException;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
@@ -102,8 +101,8 @@ class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
-  public SocketAddress getSocketAddress() {
-    return root.getSocketAddress();
+  public HostPort getHostPort() {
+    return root.getHostPort();
   }
 
   public ByteBuffer getWbuf() {

--- a/src/main/java/net/spy/memcached/TapClient.java
+++ b/src/main/java/net/spy/memcached/TapClient.java
@@ -23,7 +23,6 @@
 package net.spy.memcached;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -53,7 +52,7 @@ public class TapClient {
   protected BlockingQueue<Object> rqueue;
   protected final HashMap<TapStream, TapConnectionProvider> omap;
   protected long messagesRead;
-  private List<InetSocketAddress> addrs;
+  private List<HostPort> addrs;
 
   /**
    * Creates a tap client against the specified servers.
@@ -64,7 +63,7 @@ public class TapClient {
    *
    * @param ia the addresses of each node in the cluster.
    */
-  public TapClient(InetSocketAddress... ia) {
+  public TapClient(HostPort... ia) {
     this(Arrays.asList(ia));
   }
 
@@ -77,7 +76,7 @@ public class TapClient {
    *
    * @param addrs a list of addresses containing each node in the cluster.
    */
-  public TapClient(List<InetSocketAddress> addrs) {
+  public TapClient(List<HostPort> addrs) {
     this.rqueue = new LinkedBlockingQueue<Object>();
     this.omap = new HashMap<TapStream, TapConnectionProvider>();
     this.addrs = addrs;

--- a/src/main/java/net/spy/memcached/TapConnectionProvider.java
+++ b/src/main/java/net/spy/memcached/TapConnectionProvider.java
@@ -23,8 +23,6 @@
 package net.spy.memcached;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -63,7 +61,7 @@ public class TapConnectionProvider extends SpyObject implements
    * @param ia the memcached locations
    * @throws IOException if connections cannot be established
    */
-  public TapConnectionProvider(InetSocketAddress... ia) throws IOException {
+  public TapConnectionProvider(HostPort... ia) throws IOException {
     this(new BinaryConnectionFactory(), Arrays.asList(ia));
   }
 
@@ -73,7 +71,7 @@ public class TapConnectionProvider extends SpyObject implements
    * @param addrs the socket addrs
    * @throws IOException if connections cannot be established
    */
-  public TapConnectionProvider(List<InetSocketAddress> addrs)
+  public TapConnectionProvider(List<HostPort> addrs)
     throws IOException {
     this(new BinaryConnectionFactory(), addrs);
   }
@@ -86,7 +84,7 @@ public class TapConnectionProvider extends SpyObject implements
    * @throws IOException if connections cannot be established
    */
   public TapConnectionProvider(ConnectionFactory cf,
-      List<InetSocketAddress> addrs) throws IOException {
+      List<HostPort> addrs) throws IOException {
     if (cf == null) {
       throw new NullPointerException("Connection factory required");
     }
@@ -137,7 +135,7 @@ public class TapConnectionProvider extends SpyObject implements
     if (rv) {
       for (MemcachedNode node : conn.getLocator().getAll()) {
         if (node.isActive()) {
-          obs.connectionEstablished(node.getSocketAddress(), -1);
+          obs.connectionEstablished(node.getHostPort(), -1);
         }
       }
     }
@@ -154,28 +152,28 @@ public class TapConnectionProvider extends SpyObject implements
     return conn.removeObserver(obs);
   }
 
-  public void connectionEstablished(SocketAddress sa, int reconnectCount) {
+  public void connectionEstablished(HostPort hp, int reconnectCount) {
     if (authDescriptor != null) {
       if (authDescriptor.authThresholdReached()) {
         this.shutdown();
       } else {
-        authMonitor.authConnection(conn, opFact, authDescriptor, findNode(sa));
+        authMonitor.authConnection(conn, opFact, authDescriptor, findNode(hp));
       }
     }
   }
 
-  private MemcachedNode findNode(SocketAddress sa) {
+  private MemcachedNode findNode(HostPort hp) {
     MemcachedNode node = null;
     for (MemcachedNode n : conn.getLocator().getAll()) {
-      if (n.getSocketAddress().equals(sa)) {
+      if (n.getHostPort().equals(hp)) {
         node = n;
       }
     }
-    assert node != null : "Couldn't find node connected to " + sa;
+    assert node != null : "Couldn't find node connected to " + hp;
     return node;
   }
 
-  public void connectionLost(SocketAddress sa) {
+  public void connectionLost(HostPort hp) {
     // Don't care.
   }
 

--- a/src/main/java/net/spy/memcached/auth/AuthThread.java
+++ b/src/main/java/net/spy/memcached/auth/AuthThread.java
@@ -144,7 +144,7 @@ public class AuthThread extends SpyThread {
     getLogger().log(level, msg);
 
     if (supportedMechs == null || supportedMechs.length == 0) {
-      getLogger().warn("Authentication failed to " + node.getSocketAddress()
+      getLogger().warn("Authentication failed to " + node.getHostPort()
         + ", got empty SASL auth mech list.");
       throw new IllegalStateException("Got empty SASL auth mech list.");
     }
@@ -164,7 +164,7 @@ public class AuthThread extends SpyThread {
           if (val.getMessage().length() == 0) {
             done.set(true);
             node.authComplete();
-            getLogger().info("Authenticated to " + node.getSocketAddress());
+            getLogger().info("Authenticated to " + node.getHostPort());
           } else {
             foundStatus.set(val);
           }
@@ -210,7 +210,7 @@ public class AuthThread extends SpyThread {
       priorStatus = foundStatus.get();
       if (priorStatus != null) {
         if (!priorStatus.isSuccess()) {
-          getLogger().warn("Authentication failed to " + node.getSocketAddress()
+          getLogger().warn("Authentication failed to " + node.getHostPort()
             + ", Status: " + priorStatus);
         }
       }
@@ -228,11 +228,11 @@ public class AuthThread extends SpyThread {
     final String [] supportedMechs) {
     if (st == null) {
       return opFact.saslAuth(supportedMechs,
-          node.getSocketAddress().toString(), null,
+          node.getHostPort().toString(), null,
           authDescriptor.getCallback(), cb);
     } else {
       return opFact.saslStep(supportedMechs, KeyUtil.getKeyBytes(
-          st.getMessage()), node.getSocketAddress().toString(), null,
+          st.getMessage()), node.getHostPort().toString(), null,
           authDescriptor.getCallback(), cb);
     }
   }

--- a/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
@@ -68,7 +68,7 @@ public class CheckedOperationTimeoutException extends TimeoutException {
         rv.append(", ");
       }
       MemcachedNode node = op == null ? null : op.getHandlingNode();
-      rv.append(node == null ? "<unknown>" : node.getSocketAddress());
+      rv.append(node == null ? "<unknown>" : node.getHostPort());
     }
     return rv.toString();
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
@@ -23,11 +23,11 @@
 
 package net.spy.memcached.protocol.ascii;
 
-import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ConnectionFactory;
+import net.spy.memcached.HostPort;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
@@ -39,12 +39,19 @@ import net.spy.memcached.protocol.TCPMemcachedNodeImpl;
  */
 public final class AsciiMemcachedNodeImpl extends TCPMemcachedNodeImpl {
 
-  public AsciiMemcachedNodeImpl(SocketAddress sa, SocketChannel c, int bufSize,
-      BlockingQueue<Operation> rq, BlockingQueue<Operation> wq,
-      BlockingQueue<Operation> iq, Long opQueueMaxBlockTimeNs, long dt,
-      long at, ConnectionFactory fa) {
+  public AsciiMemcachedNodeImpl(
+      HostPort hp,
+      SocketChannel c,
+      int bufSize,
+      BlockingQueue<Operation> rq,
+      BlockingQueue<Operation> wq,
+      BlockingQueue<Operation> iq,
+      Long opQueueMaxBlockTimeNs,
+      long dt,
+      long at,
+      ConnectionFactory fa) {
     // ASCII never does auth
-    super(sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs, false, dt, at, fa);
+    super(hp, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs, false, dt, at, fa);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
@@ -23,11 +23,11 @@
 
 package net.spy.memcached.protocol.binary;
 
-import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ConnectionFactory;
+import net.spy.memcached.HostPort;
 import net.spy.memcached.ops.CASOperation;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.Operation;
@@ -45,12 +45,19 @@ public class BinaryMemcachedNodeImpl extends TCPMemcachedNodeImpl {
   private static final int MAX_SET_OPTIMIZATION_COUNT = 65535;
   private static final int MAX_SET_OPTIMIZATION_BYTES = 2 * 1024 * 1024;
 
-  public BinaryMemcachedNodeImpl(SocketAddress sa, SocketChannel c,
-      int bufSize, BlockingQueue<Operation> rq, BlockingQueue<Operation> wq,
-      BlockingQueue<Operation> iq, Long opQueueMaxBlockTimeNs,
-      boolean waitForAuth, long dt, long at, ConnectionFactory fa) {
-    super(sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs, waitForAuth, dt,
-      at, fa);
+  public BinaryMemcachedNodeImpl(
+      HostPort hp,
+      SocketChannel c,
+      int bufSize,
+      BlockingQueue<Operation> rq,
+      BlockingQueue<Operation> wq,
+      BlockingQueue<Operation> iq,
+      Long opQueueMaxBlockTimeNs,
+      boolean waitForAuth,
+      long dt,
+      long at,
+      ConnectionFactory fa) {
+    super(hp, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs, waitForAuth, dt, at, fa);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/spring/MemcachedClientFactoryBean.java
+++ b/src/main/java/net/spy/memcached/spring/MemcachedClientFactoryBean.java
@@ -69,7 +69,8 @@ public class MemcachedClientFactoryBean implements FactoryBean {
 
   @Override
   public Object getObject() throws Exception {
-    return new MemcachedClient(connectionFactoryBuilder.build(),
+    return new MemcachedClient(
+        connectionFactoryBuilder.build(),
         AddrUtil.getAddresses(servers));
   }
 

--- a/src/main/java/net/spy/memcached/util/DefaultKetamaNodeLocatorConfiguration.java
+++ b/src/main/java/net/spy/memcached/util/DefaultKetamaNodeLocatorConfiguration.java
@@ -48,7 +48,7 @@ public class DefaultKetamaNodeLocatorConfiguration implements
    * @param node The node which we're interested in
    * @return String the socket address of that node.
    */
-  protected String getSocketAddressForNode(MemcachedNode node) {
+  protected String getAddressForNode(MemcachedNode node) {
     // Using the internal map retrieve the socket addresses
     // for given nodes.
     // I'm aware that this code is inherently thread-unsafe as
@@ -59,7 +59,7 @@ public class DefaultKetamaNodeLocatorConfiguration implements
     // all other cases should be as fast as possible.
     String result = socketAddresses.get(node);
     if (result == null) {
-      result = String.valueOf(node.getSocketAddress());
+      result = String.valueOf(node.getHostPort());
       if (result.startsWith("/")) {
         result = result.substring(1);
       }
@@ -115,6 +115,6 @@ public class DefaultKetamaNodeLocatorConfiguration implements
    * @return The key that represents the specific repetition of the node
    */
   public String getKeyForNode(MemcachedNode node, int repetition) {
-    return getSocketAddressForNode(node) + "-" + repetition;
+    return getAddressForNode(node) + "-" + repetition;
   }
 }

--- a/src/test/java/net/spy/memcached/AddrUtilTest.java
+++ b/src/test/java/net/spy/memcached/AddrUtilTest.java
@@ -22,7 +22,6 @@
 
 package net.spy.memcached;
 
-import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -35,14 +34,14 @@ import junit.framework.TestCase;
 public class AddrUtilTest extends TestCase {
 
   public void testSingle() throws Exception {
-    List<InetSocketAddress> addrs = AddrUtil.getAddresses("www.google.com:80");
+    List<HostPort> addrs = AddrUtil.getAddresses("www.google.com:80");
     assertEquals(1, addrs.size());
     assertEquals("www.google.com", addrs.get(0).getHostName());
     assertEquals(80, addrs.get(0).getPort());
   }
 
   public void testTwo() throws Exception {
-    List<InetSocketAddress> addrs =
+    List<HostPort> addrs =
         AddrUtil.getAddresses("www.google.com:80 www.yahoo.com:81");
     assertEquals(2, addrs.size());
     assertEquals("www.google.com", addrs.get(0).getHostName());
@@ -52,7 +51,7 @@ public class AddrUtilTest extends TestCase {
   }
 
   public void testThree() throws Exception {
-    List<InetSocketAddress> addrs = AddrUtil
+    List<HostPort> addrs = AddrUtil
         .getAddresses(" ,  www.google.com:80 ,, ,, www.yahoo.com:81 , ,,");
     assertEquals(2, addrs.size());
     assertEquals("www.google.com", addrs.get(0).getHostName());
@@ -64,7 +63,7 @@ public class AddrUtilTest extends TestCase {
   public void testBrokenHost() throws Exception {
     String s = "www.google.com:80 www.yahoo.com:81:more";
     try {
-      List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
+      List<HostPort> addrs = AddrUtil.getAddresses(s);
       fail("Expected failure, got " + addrs);
     } catch (NumberFormatException e) {
       e.printStackTrace();
@@ -75,7 +74,7 @@ public class AddrUtilTest extends TestCase {
   public void testBrokenHost2() throws Exception {
     String s = "www.google.com:80 www.yahoo.com";
     try {
-      List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
+      List<HostPort> addrs = AddrUtil.getAddresses(s);
       fail("Expected failure, got " + addrs);
     } catch (IllegalArgumentException e) {
       assertEquals("Invalid server ``www.yahoo.com'' in list:  " + s,
@@ -86,7 +85,7 @@ public class AddrUtilTest extends TestCase {
   public void testBrokenList() throws Exception {
     String s = "";
     try {
-      List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
+      List<HostPort> addrs = AddrUtil.getAddresses(s);
       fail("Expected failure, got " + addrs);
     } catch (IllegalArgumentException e) {
       assertEquals("No hosts in list:  ``''", e.getMessage());
@@ -96,7 +95,7 @@ public class AddrUtilTest extends TestCase {
   public void testBrokenList2() throws Exception {
     String s = "   ";
     try {
-      List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
+      List<HostPort> addrs = AddrUtil.getAddresses(s);
       fail("Expected failure, got " + addrs);
     } catch (IllegalArgumentException e) {
       assertEquals("No hosts in list:  ``   ''", e.getMessage());
@@ -106,7 +105,7 @@ public class AddrUtilTest extends TestCase {
   public void testNullList() throws Exception {
     String s = null;
     try {
-      List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
+      List<HostPort> addrs = AddrUtil.getAddresses(s);
       fail("Expected failure, got " + addrs);
     } catch (NullPointerException e) {
       assertEquals("Null host list", e.getMessage());
@@ -114,7 +113,7 @@ public class AddrUtilTest extends TestCase {
   }
 
   public void testIPv6Host() throws Exception {
-    List<InetSocketAddress> addrs = AddrUtil.getAddresses("::1:80");
+    List<HostPort> addrs = AddrUtil.getAddresses("::1:80");
     assertEquals(1, addrs.size());
 
     Set<String> validLocalhostNames = new HashSet<String>();
@@ -122,7 +121,7 @@ public class AddrUtilTest extends TestCase {
     validLocalhostNames.add("ip6-localhost");
     validLocalhostNames.add("0:0:0:0:0:0:0:1");
     validLocalhostNames.add("localhost6.localdomain6");
-    assert (validLocalhostNames.contains(addrs.get(0).getHostName()));
+    assert (validLocalhostNames.contains(addrs.get(0).getAddress().getHostName()));
     assertEquals(80, addrs.get(0).getPort());
   }
 }

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -23,7 +23,6 @@
 
 package net.spy.memcached;
 
-import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -96,7 +95,7 @@ public abstract class ClientBaseCase extends TestCase {
     }
     // some tests are invalid if using moxi
 
-    Map<SocketAddress, Map<String, String>> stats = client.getStats("proxy");
+    Map<HostPort, Map<String, String>> stats = client.getStats("proxy");
     for (Map<String, String> node : stats.values()) {
       if (node.get("basic:version") != null) {
         moxi = true;

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -24,7 +24,6 @@
 package net.spy.memcached;
 
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
 import java.util.Collections;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -91,8 +90,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
     SocketChannel sc = SocketChannel.open();
     try {
       assertTrue(f.createMemcachedNode(
-          InetSocketAddress.createUnresolved("localhost",
-              TestConfig.PORT_NUMBER), sc, 1)
+          new HostPort("localhost", TestConfig.PORT_NUMBER), sc, 1)
           instanceof AsciiMemcachedNodeImpl);
     } finally {
       sc.close();
@@ -109,11 +107,11 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
 
   public void testModifications() throws Exception {
     ConnectionObserver testObserver = new ConnectionObserver() {
-      public void connectionLost(SocketAddress sa) {
+      public void connectionLost(HostPort hp) {
         // none
       }
 
-      public void connectionEstablished(SocketAddress sa, int reconnectCount) {
+      public void connectionEstablished(HostPort hp, int reconnectCount) {
         // none
       }
     };
@@ -161,16 +159,14 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
     assertEquals(f.getAuthWaitTime(), 3000);
 
     MemcachedNode n = new MockMemcachedNode(
-        InetSocketAddress.createUnresolved("localhost",
-            TestConfig.PORT_NUMBER));
+        new HostPort("localhost", TestConfig.PORT_NUMBER));
     assertTrue(f.createLocator(Collections.singletonList(n))
         instanceof KetamaNodeLocator);
 
     SocketChannel sc = SocketChannel.open();
     try {
       assertTrue(f.createMemcachedNode(
-          InetSocketAddress.createUnresolved("localhost",
-              TestConfig.PORT_NUMBER), sc, 1)
+          new HostPort("lcoalhost", TestConfig.PORT_NUMBER), sc, 1)
           instanceof BinaryMemcachedNodeImpl);
     } finally {
       sc.close();

--- a/src/test/java/net/spy/memcached/ConsistentHashingTest.java
+++ b/src/test/java/net/spy/memcached/ConsistentHashingTest.java
@@ -23,7 +23,6 @@
 
 package net.spy.memcached;
 
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -80,8 +79,8 @@ public class ConsistentHashingTest extends TestCase {
         failed = true;
         System.out.println("---------------");
         System.out.println("Key: " + key);
-        System.out.println("Small: " + smallNode.getSocketAddress());
-        System.out.println("Large: " + largeNode.getSocketAddress());
+        System.out.println("Small: " + smallNode.getHostPort());
+        System.out.println("Large: " + largeNode.getHostPort());
       }
     }
     assertFalse(failed);
@@ -93,7 +92,7 @@ public class ConsistentHashingTest extends TestCase {
         final MemcachedNode newNode = smLocator.getNodeForKey(key);
         if (!smaller.contains(newNode)) {
           System.out.println("Error - " + key + " -> "
-              + newNode.getSocketAddress());
+              + newNode.getHostPort());
           failed = true;
         }
       }
@@ -138,10 +137,10 @@ public class ConsistentHashingTest extends TestCase {
     return results;
   }
 
-  private List<MemcachedNode> createNodes(List<InetSocketAddress> addresses) {
+  private List<MemcachedNode> createNodes(List<HostPort> addresses) {
     List<MemcachedNode> results = new ArrayList<MemcachedNode>();
 
-    for (InetSocketAddress addr : addresses) {
+    for (HostPort addr : addresses) {
       results.add(new MockMemcachedNode(addr));
     }
 

--- a/src/test/java/net/spy/memcached/KetamaNodeLocatorTest.java
+++ b/src/test/java/net/spy/memcached/KetamaNodeLocatorTest.java
@@ -23,7 +23,6 @@
 
 package net.spy.memcached;
 
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -38,9 +37,8 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
   protected void setupNodes(HashAlgorithm alg, int n) {
     super.setupNodes(n);
     for (int i = 0; i < nodeMocks.length; i++) {
-      nodeMocks[i].expects(atLeastOnce()).method("getSocketAddress")
-          .will(returnValue(InetSocketAddress.createUnresolved("127.0.0.1",
-          10000 + i)));
+      nodeMocks[i].expects(atLeastOnce()).method("getHostPort")
+          .will(returnValue(new HostPort("127.0.0.1", 10000 + i)));
     }
 
     locator = new KetamaNodeLocator(Arrays.asList(nodes), alg);
@@ -72,9 +70,8 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
 
     ArrayList<MemcachedNode> toUpdate = new ArrayList<MemcachedNode>();
     Mock mock = mock(MemcachedNode.class);
-    mock.expects(atLeastOnce()).method("getSocketAddress")
-          .will(returnValue(InetSocketAddress.createUnresolved("127.0.0.1",
-          10000)));
+    mock.expects(atLeastOnce()).method("getHostPort")
+          .will(returnValue(new HostPort("127.0.0.1", 10000)));
     toUpdate.add((MemcachedNode) mock.proxy());
     locator.updateLocator(toUpdate);
 
@@ -175,9 +172,9 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
     setupNodes(servers.length);
 
     for (int i = 0; i < nodeMocks.length; i++) {
-      List<InetSocketAddress> a = AddrUtil.getAddresses(servers[i]);
+      List<HostPort> a = AddrUtil.getAddresses(servers[i]);
 
-      nodeMocks[i].expects(atLeastOnce()).method("getSocketAddress")
+      nodeMocks[i].expects(atLeastOnce()).method("getHostPort")
           .will(returnValue(a.iterator().next()));
 
     }
@@ -1817,7 +1814,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
       String k = s[0];
       String server = s[1];
       MemcachedNode n = locator.getPrimary(k);
-      assertEquals("/" + server, n.getSocketAddress().toString());
+      assertEquals(server, n.getHostPort().toString());
     }
 
   }

--- a/src/test/java/net/spy/memcached/LongClientTest.java
+++ b/src/test/java/net/spy/memcached/LongClientTest.java
@@ -46,8 +46,7 @@ public class LongClientTest extends ClientBaseCase {
     client.shutdown();
     initClient(new DefaultConnectionFactory() {
       @Override
-      public MemcachedConnection
-      createConnection(List<InetSocketAddress> addrs) throws IOException {
+      public MemcachedConnection createConnection(List<HostPort> addrs) throws IOException {
         MemcachedConnection rv = super.createConnection(addrs);
         return rv;
       }

--- a/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
@@ -24,9 +24,6 @@
 package net.spy.memcached;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +56,7 @@ public class MemcachedClientConstructorTest extends TestCase {
   }
 
   private void assertWorking() throws Exception {
-    Map<SocketAddress, String> versions = client.getVersions();
+    Map<HostPort, String> versions = client.getVersions();
     assertEquals("/" + TestConfig.IPV4_ADDR + ":" + TestConfig.PORT_NUMBER,
         versions.keySet().iterator().next().toString());
   }
@@ -71,8 +68,9 @@ public class MemcachedClientConstructorTest extends TestCase {
 
   public void testVarargConstructor() throws Exception {
     client =
-        new MemcachedClient(new InetSocketAddress(
-            InetAddress.getByName(TestConfig.IPV4_ADDR),
+        new MemcachedClient(
+            new HostPort(
+                TestConfig.IPV4_ADDR,
                 TestConfig.PORT_NUMBER));
     assertWorking();
   }
@@ -88,7 +86,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 
   public void testNulListConstructor() throws Exception {
     try {
-      List<InetSocketAddress> l = null;
+      List<HostPort> l = null;
       client = new MemcachedClient(l);
       fail("Expected null pointer exception, got " + client);
     } catch (NullPointerException e) {
@@ -98,7 +96,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 
   public void testEmptyListConstructor() throws Exception {
     try {
-      client = new MemcachedClient(Collections.<InetSocketAddress>emptyList());
+      client = new MemcachedClient(Collections.<HostPort>emptyList());
       fail("Expected illegal arg exception, got " + client);
     } catch (IllegalArgumentException e) {
       assertArgRequired(e);
@@ -165,8 +163,7 @@ public class MemcachedClientConstructorTest extends TestCase {
     try {
       client = new MemcachedClient(new DefaultConnectionFactory() {
         @Override
-        public MemcachedConnection createConnection(
-            List<InetSocketAddress> addrs) throws IOException {
+        public MemcachedConnection createConnection(List<HostPort> addrs) throws IOException {
           return null;
         }
       }, AddrUtil.getAddresses(TestConfig.IPV4_ADDR + ":"

--- a/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
@@ -45,8 +45,7 @@ public class MemcachedConnectionTest extends TestCase {
 
   public void testConnectionsStatus() throws Exception {
     ConnectionFactory factory = new DefaultConnectionFactory();
-    List<InetSocketAddress> addresses =
-      AddrUtil.getAddresses(TestConfig.IPV4_ADDR + ":11211");
+    List<HostPort> addresses = AddrUtil.getAddresses(TestConfig.IPV4_ADDR + ":11211");
     Collection<ConnectionObserver> observers =
       new ArrayList<ConnectionObserver>();
     MemcachedConnection mcc = new MemcachedConnection(10240, factory, addresses,
@@ -61,12 +60,12 @@ public class MemcachedConnectionTest extends TestCase {
     OperationFactory opfactory = new BinaryOperationFactory();
 
     MemcachedNode node = new MockMemcachedNode(
-      new InetSocketAddress(TestConfig.IPV4_ADDR, TestConfig.PORT_NUMBER));
+      new HostPort(TestConfig.IPV4_ADDR, TestConfig.PORT_NUMBER));
     MemcachedNode node2 = new MockMemcachedNode(
-      new InetSocketAddress("invalidIpAddr", TestConfig.PORT_NUMBER));
+      new HostPort("invalidIpAddr", TestConfig.PORT_NUMBER));
 
-    List<InetSocketAddress> nodes = new ArrayList<InetSocketAddress>();
-    nodes.add((InetSocketAddress)node.getSocketAddress());
+    List<HostPort> nodes = new ArrayList<HostPort>();
+    nodes.add(node.getHostPort());
 
     MemcachedConnection conn = new MemcachedConnection(
       100, factory, nodes, observers, FailureMode.Retry, opfactory);

--- a/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
@@ -25,8 +25,6 @@ package net.spy.memcached;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -40,17 +38,17 @@ import org.jmock.MockObjectTestCase;
 public class MemcachedNodeROImplTest extends MockObjectTestCase {
 
   public void testReadOnliness() throws Exception {
-    SocketAddress sa = new InetSocketAddress(TestConfig.PORT_NUMBER);
+    HostPort hp = new HostPort("", TestConfig.PORT_NUMBER);
     Mock m = mock(MemcachedNode.class, "node");
     MemcachedNodeROImpl node =
         new MemcachedNodeROImpl((MemcachedNode) m.proxy());
-    m.expects(once()).method("getSocketAddress").will(returnValue(sa));
+    m.expects(once()).method("getHostPort").will(returnValue(hp));
 
-    assertSame(sa, node.getSocketAddress());
+    assertSame(hp, node.getHostPort());
     assertEquals(m.proxy().toString(), node.toString());
 
     Set<String> acceptable = new HashSet<String>(Arrays.asList("toString",
-        "getSocketAddress", "getBytesRemainingToWrite", "getReconnectCount",
+        "getHostPort", "getBytesRemainingToWrite", "getReconnectCount",
         "getSelectionOps", "hasReadOp", "hasWriteOp", "isActive"));
 
     for (Method meth : MemcachedNode.class.getMethods()) {

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -24,8 +24,6 @@
 package net.spy.memcached;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
@@ -37,14 +35,14 @@ import net.spy.memcached.ops.Operation;
  * A MockMemcachedNode.
  */
 public class MockMemcachedNode implements MemcachedNode {
-  private final InetSocketAddress socketAddress;
+  private final HostPort hostPort;
 
-  public SocketAddress getSocketAddress() {
-    return socketAddress;
+  public HostPort getHostPort() {
+    return hostPort;
   }
 
-  public MockMemcachedNode(InetSocketAddress socketAddress) {
-    this.socketAddress = socketAddress;
+  public MockMemcachedNode(HostPort hostPort) {
+    this.hostPort = hostPort;
   }
 
   @Override
@@ -58,8 +56,8 @@ public class MockMemcachedNode implements MemcachedNode {
 
     MockMemcachedNode that = (MockMemcachedNode) o;
 
-    if (socketAddress != null ? !socketAddress.equals(that.socketAddress)
-        : that.socketAddress != null) {
+    if (hostPort != null ? !hostPort.equals(that.hostPort)
+        : that.hostPort != null) {
       return false;
     }
 
@@ -68,7 +66,7 @@ public class MockMemcachedNode implements MemcachedNode {
 
   @Override
   public int hashCode() {
-    return (socketAddress != null ? socketAddress.hashCode() : 0);
+    return (hostPort != null ? hostPort.hashCode() : 0);
   }
 
   public void copyInputQueue() {

--- a/src/test/java/net/spy/memcached/ObserverTest.java
+++ b/src/test/java/net/spy/memcached/ObserverTest.java
@@ -22,7 +22,6 @@
 
 package net.spy.memcached;
 
-import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
@@ -49,11 +48,11 @@ public class ObserverTest extends ClientBaseCase {
     final CountDownLatch latch = new CountDownLatch(1);
     final ConnectionObserver obs = new ConnectionObserver() {
 
-      public void connectionEstablished(SocketAddress sa, int reconnectCount) {
+      public void connectionEstablished(HostPort hp, int reconnectCount) {
         latch.countDown();
       }
 
-      public void connectionLost(SocketAddress sa) {
+      public void connectionLost(HostPort hp) {
         assert false : "Should not see this.";
       }
 
@@ -75,12 +74,12 @@ public class ObserverTest extends ClientBaseCase {
   }
 
   static class LoggingObserver extends SpyObject implements ConnectionObserver {
-    public void connectionEstablished(SocketAddress sa, int reconnectCount) {
-      getLogger().info("Connection established to %s (%s)", sa, reconnectCount);
+    public void connectionEstablished(HostPort hp, int reconnectCount) {
+      getLogger().info("Connection established to %s (%s)", hp, reconnectCount);
     }
 
-    public void connectionLost(SocketAddress sa) {
-      getLogger().info("Connection lost from %s", sa);
+    public void connectionLost(HostPort hp) {
+      getLogger().info("Connection lost from %s", hp);
     }
   }
 }

--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -23,7 +23,6 @@
 
 package net.spy.memcached;
 
-import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,9 +37,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertSame;
-import static junit.framework.Assert.assertTrue;
 
 import net.spy.memcached.compat.SyncThread;
 import net.spy.memcached.internal.BulkFuture;
@@ -73,7 +69,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   public void testGetStats() throws Exception {
-    Map<SocketAddress, Map<String, String>> stats = client.getStats();
+    Map<HostPort, Map<String, String>> stats = client.getStats();
     System.out.println("Stats:  " + stats);
     assertEquals(1, stats.size());
     Map<String, String> oneStat = stats.values().iterator().next();
@@ -87,7 +83,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     // There needs to at least have been one value set or there may be
     // no slabs to check.
     client.set("slabinitializer", 0, "hi");
-    Map<SocketAddress, Map<String, String>> stats = client.getStats("slabs");
+    Map<HostPort, Map<String, String>> stats = client.getStats("slabs");
     System.out.println("Stats:  " + stats);
     assertEquals(1, stats.size());
     Map<String, String> oneStat = stats.values().iterator().next();
@@ -104,7 +100,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     // use flush when testing, so we check that there's at least
     // one.
     client.set("sizeinitializer", 0, "hi");
-    Map<SocketAddress, Map<String, String>> stats = client.getStats("sizes");
+    Map<HostPort, Map<String, String>> stats = client.getStats("sizes");
     System.out.println("Stats sizes:  " + stats);
     assertEquals(1, stats.size());
     Map<String, String> oneStat = stats.values().iterator().next();
@@ -516,9 +512,9 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   protected abstract String getExpectedVersionSource();
 
   public void testGetVersions() throws Exception {
-    Map<SocketAddress, String> vs = client.getVersions();
+    Map<HostPort, String> vs = client.getVersions();
     assertEquals(1, vs.size());
-    Map.Entry<SocketAddress, String> me = vs.entrySet().iterator().next();
+    Map.Entry<HostPort, String> me = vs.entrySet().iterator().next();
     assertEquals(getExpectedVersionSource(), me.getKey().toString());
     assertNotNull(me.getValue());
   }
@@ -672,7 +668,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
         client.shutdown(5, TimeUnit.SECONDS));
 
     syncGetTimeoutsInitClient();
-    Thread.sleep(100); // allow connections to be established
+    Thread.sleep(1000); // allow connections to be established
 
     int i = 0;
     GetFuture<Object> g = null;
@@ -686,7 +682,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
       assert !g.getStatus().isSuccess();
       System.err.println("Got a timeout at iteration " + i + ".");
     }
-    Thread.sleep(100); // let whatever caused the timeout to pass
+    Thread.sleep(1000); // let whatever caused the timeout to pass
     try {
       if (value.equals(client.asyncGet(key).get(30, TimeUnit.SECONDS))) {
         System.err.println("Got the right value.");
@@ -727,7 +723,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
         client.shutdown(1, TimeUnit.MILLISECONDS));
 
     try {
-      Map<SocketAddress, String> m = client.getVersions();
+      Map<HostPort, String> m = client.getVersions();
       fail("Expected failure, got " + m);
     } catch (IllegalStateException e) {
       assertEquals("Shutting down", e.getMessage());

--- a/src/test/java/net/spy/memcached/QueueOverflowTest.java
+++ b/src/test/java/net/spy/memcached/QueueOverflowTest.java
@@ -24,7 +24,6 @@
 package net.spy.memcached;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -36,6 +35,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.ops.Operation;
 
 /**
@@ -52,7 +52,7 @@ public class QueueOverflowTest extends ClientBaseCase {
     initClient(new DefaultConnectionFactory(5, 1024) {
       @Override
       public MemcachedConnection
-      createConnection(List<InetSocketAddress> addrs) throws IOException {
+      createConnection(List<HostPort> addrs) throws IOException {
         MemcachedConnection rv = super.createConnection(addrs);
         return rv;
       }
@@ -146,7 +146,7 @@ public class QueueOverflowTest extends ClientBaseCase {
     } catch (IllegalStateException e) {
       // expected
     }
-    Thread.sleep(50);
+    Thread.sleep(100);
     for (Future<Object> f : c) {
       try {
         f.get(1, TimeUnit.SECONDS);
@@ -156,7 +156,7 @@ public class QueueOverflowTest extends ClientBaseCase {
         // OK, at least we got one back.
       }
     }
-    Thread.sleep(500);
+    Thread.sleep(1000);
     assertTrue(client.set("kx", 0, "woo").get(5, TimeUnit.SECONDS));
   }
 }

--- a/src/test/java/net/spy/memcached/WokenUpOnIdleTest.java
+++ b/src/test/java/net/spy/memcached/WokenUpOnIdleTest.java
@@ -26,7 +26,6 @@ import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -49,7 +48,7 @@ public class WokenUpOnIdleTest {
       latch,
       1024,
       new BinaryConnectionFactory(),
-      Arrays.asList(new InetSocketAddress(11211)),
+      Arrays.asList(new HostPort("", 11211)),
       Collections.<ConnectionObserver>emptyList(),
       FailureMode.Redistribute,
       new BinaryOperationFactory()
@@ -61,7 +60,7 @@ public class WokenUpOnIdleTest {
   static class InstrumentedConnection extends MemcachedConnection {
     final CountDownLatch latch;
     InstrumentedConnection(CountDownLatch latch, int bufSize, ConnectionFactory f,
-      List<InetSocketAddress> a, Collection<ConnectionObserver> obs,
+      List<HostPort> a, Collection<ConnectionObserver> obs,
       FailureMode fm, OperationFactory opfactory) throws IOException {
       super(bufSize, f, a, obs, fm, opfactory);
       this.latch = latch;

--- a/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
+++ b/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import junit.framework.TestCase;
+import net.spy.memcached.HostPort;
 import net.spy.memcached.MockMemcachedNode;
 import net.spy.memcached.TestConfig;
 import net.spy.memcached.ops.Operation;
@@ -76,8 +77,7 @@ public class CheckedOperationTimeoutExceptionTest extends TestCase {
   private TestOperation buildOp(int portNum) {
     TestOperation op = new TestOperation();
     MockMemcachedNode node =
-        new MockMemcachedNode(InetSocketAddress.createUnresolved(
-          TestConfig.IPV4_ADDR, portNum));
+        new MockMemcachedNode(new HostPort(TestConfig.IPV4_ADDR, portNum));
     op.setHandlingNode(node);
     return op;
   }


### PR DESCRIPTION
Change the internal host information from SocketAddress to an internal
HostPort class. Only resolve the HostPort into an InetSocketAddress right
before a connection (or reconnection) is made. This allows changes in DNS
mappings to be detected (e.g. when using AWS Elastic IPs).
