### PR TITLE
In binary protocol we should not limit the length of key. Key length …

### DIFF
--- a/src/main/java/net/spy/memcached/util/StringUtils.java
+++ b/src/main/java/net/spy/memcached/util/StringUtils.java
@@ -123,7 +123,7 @@ public final class StringUtils {
     byte[] keyBytes = KeyUtil.getKeyBytes(key);
     int keyLength = keyBytes.length;
 
-    if (keyLength > MAX_KEY_LENGTH) {
+    if (keyLength > MAX_KEY_LENGTH && !binary) {
       throw KEY_TOO_LONG_EXCEPTION;
     }
 


### PR DESCRIPTION
In binary protocol we should not limit the length of key. Key length is 2^16.
