### PR TITLE
Remove the no-operation isInterrupted() call.

### DIFF
--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -207,6 +207,9 @@ public class OperationFuture<T>
  /**
    * Get the CAS for this operation.
    *
+   * The interrupted status of the current thread is cleared by this method.
+   * Inspect the returned OperationStatus to check whether an interruption has taken place.
+   *
    * @throws UnsupportedOperationException If this is for an ASCII protocol
    * configured client.
    * @return the CAS for this operation or null if unsuccessful.
@@ -218,7 +221,6 @@ public class OperationFuture<T>
         get();
       } catch (InterruptedException e) {
         status = new OperationStatus(false, "Interrupted", StatusCode.INTERRUPTED);
-        Thread.currentThread().isInterrupted();
       } catch (ExecutionException e) {
         getLogger().warn("Error getting cas of operation", e);
       }
@@ -235,6 +237,9 @@ public class OperationFuture<T>
    * Note that the operation status may change as the operation is tried and
    * potentially retried against the servers specified by the NodeLocator.
    *
+   * The interrupted status of the current thread is cleared by this method.
+   * Inspect the returned OperationStatus to check whether an interruption has taken place.
+   *
    * @return OperationStatus
    */
   public OperationStatus getStatus() {
@@ -243,7 +248,6 @@ public class OperationFuture<T>
         get();
       } catch (InterruptedException e) {
         status = new OperationStatus(false, "Interrupted", StatusCode.INTERRUPTED);
-        Thread.currentThread().isInterrupted();
       } catch (ExecutionException e) {
         getLogger().warn("Error getting status of operation", e);
       }


### PR DESCRIPTION
This pull request removes a NOP call.

Thread.currentThread().isInterrupted() is a no-op call, as the returned value is not used. The call does not have any side effects on interruption status or memory visibility (happens-before). The interrupt status gets actually cleared by the catch (InterruptedException) clause, and I added documentation that documents the interruption policy.
