### PR TITLE
squid:S1698 Object should be compared with equals()

### DIFF
--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -438,7 +438,7 @@ public class DefaultConnectionFactory extends SpyObject implements
     }
 
     String enableMetrics = System.getProperty("net.spy.metrics.enable");
-    if (enableMetrics().equals(MetricType.OFF) || enableMetrics == "false") {
+    if (MetricType.OFF.equals(enableMetrics()) || "false".equals(enableMetrics)) {
       getLogger().debug("Metric collection disabled.");
       metrics =  new NoopMetricCollector();
     } else {

--- a/src/main/java/net/spy/memcached/KetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/KetamaNodeLocator.java
@@ -175,7 +175,7 @@ public final class KetamaNodeLocator extends SpyObject implements NodeLocator {
     int numReps = config.getNodeRepetitions();
     for (MemcachedNode node : nodes) {
       // Ketama does some special work with md5 where it reuses chunks.
-      if (hashAlg == DefaultHashAlgorithm.KETAMA_HASH) {
+      if (DefaultHashAlgorithm.KETAMA_HASH.equals(hashAlg)) {
         for (int i = 0; i < numReps / 4; i++) {
           byte[] digest =
               DefaultHashAlgorithm.computeMd5(config.getKeyForNode(node, i));

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -863,7 +863,7 @@ public class MemcachedConnection extends SpyThread {
       getLogger().debug("Completed read op: %s and giving the next %d "
         + "bytes", currentOp, rbuf.remaining());
       Operation op = node.removeCurrentReadOp();
-      assert op == currentOp : "Expected to pop " + currentOp + " got "
+      assert op.equals(currentOp) : "Expected to pop " + currentOp + " got "
         + op;
 
       if (op.hasErrored()) {
@@ -878,7 +878,7 @@ public class MemcachedConnection extends SpyThread {
       ((VBucketAware) currentOp).addNotMyVbucketNode(
         currentOp.getHandlingNode());
       Operation op = node.removeCurrentReadOp();
-      assert op == currentOp : "Expected to pop " + currentOp + " got "
+      assert op.equals(currentOp) : "Expected to pop " + currentOp + " got "
         + op;
 
       retryOps.add(currentOp);
@@ -905,7 +905,7 @@ public class MemcachedConnection extends SpyThread {
       getLogger().debug("Completed read op: %s and giving the next %d bytes",
         currentOp, rbuf.remaining());
       Operation op = node.removeCurrentReadOp();
-      assert op == currentOp : "Expected to pop " + currentOp + " got " + op;
+      assert op.equals(currentOp) : "Expected to pop " + currentOp + " got " + op;
       return node.getCurrentReadOp();
     } else {
       throw new IOException("Disconnected unexpected, will reconnect.");
@@ -1126,7 +1126,7 @@ public class MemcachedConnection extends SpyThread {
             ops = SelectionKey.OP_CONNECT;
           }
           node.registerChannel(ch, ch.register(selector, ops, node));
-          assert node.getChannel() == ch : "Channel was lost.";
+          assert node.getChannel().equals(ch) : "Channel was lost.";
         } else {
           getLogger().debug("Skipping duplicate reconnect request for %s",
             node);
@@ -1247,7 +1247,7 @@ public class MemcachedConnection extends SpyThread {
     metrics.markMeter(OVERALL_REQUEST_METRIC);
 
     Selector s = selector.wakeup();
-    assert s == selector : "Wakeup returned the wrong selector.";
+    assert s.equals(selector) : "Wakeup returned the wrong selector.";
     getLogger().debug("Added %s to %s", o, node);
   }
 
@@ -1269,7 +1269,7 @@ public class MemcachedConnection extends SpyThread {
     metrics.markMeter(OVERALL_REQUEST_METRIC);
 
     Selector s = selector.wakeup();
-    assert s == selector : "Wakeup returned the wrong selector.";
+    assert s.equals(selector) : "Wakeup returned the wrong selector.";
     getLogger().debug("Added %s to %s", o, node);
   }
 
@@ -1315,7 +1315,7 @@ public class MemcachedConnection extends SpyThread {
     }
 
     Selector s = selector.wakeup();
-    assert s == selector : "Wakeup returned the wrong selector.";
+    assert s.equals(selector) : "Wakeup returned the wrong selector.";
     return latch;
   }
 
@@ -1326,7 +1326,7 @@ public class MemcachedConnection extends SpyThread {
     shutDown = true;
     try {
       Selector s = selector.wakeup();
-      assert s == selector : "Wakeup returned the wrong selector.";
+      assert s.equals(selector) : "Wakeup returned the wrong selector.";
       for (MemcachedNode node : locator.getAll()) {
         if (node.getChannel() != null) {
           node.getChannel().close();

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -154,7 +154,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     // to requeue them.
     while (hasReadOp()) {
       op = removeCurrentReadOp();
-      if (op != getCurrentWriteOp()) {
+      if (!op.equals(getCurrentWriteOp())) {
         getLogger().warn("Discarding partially completed op: %s", op);
         op.cancel();
       }
@@ -240,11 +240,11 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
         if (o.isCancelled()) {
           getLogger().debug("Not writing cancelled op.");
           Operation cancelledOp = removeCurrentWriteOp();
-          assert o == cancelledOp;
+          assert o.equals(cancelledOp);
         } else if (o.isTimedOut(defaultOpTimeout)) {
           getLogger().debug("Not writing timed out op.");
           Operation timedOutOp = removeCurrentWriteOp();
-          assert o == timedOutOp;
+          assert o.equals(timedOutOp);
         } else {
           o.writing();
           if (!(o instanceof TapAckOperationImpl)) {

--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -333,7 +333,7 @@ public  abstract class OperationImpl extends BaseOperationImpl
     int bufSize = MIN_RECV_PACKET + keyBytes.length + val.length;
 
     ByteBuffer bb = ByteBuffer.allocate(bufSize + extraLen);
-    assert bb.order() == ByteOrder.BIG_ENDIAN;
+    assert ByteOrder.BIG_ENDIAN.equals(bb.order());
     bb.put(REQ_MAGIC);
     bb.put(cmd);
     bb.putShort((short) keyBytes.length);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1698 Object should be compared with equals()

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1698

Please let me know if you have any questions.

Zeeshan
