### PR TITLE
Code Improvements: %n should be used, Collection.isEmpty() should be used

### DIFF
--- a/src/main/java/net/spy/memcached/compat/log/DefaultLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/DefaultLogger.java
@@ -77,7 +77,7 @@ public class DefaultLogger extends AbstractLogger {
         || level == Level.WARN
         || level == Level.ERROR
         || level == Level.FATAL) {
-      System.err.printf("%s %s %s:  %s\n", df.format(new Date()), level.name(),
+      System.err.printf("%s %s %s:  %s%n", df.format(new Date()), level.name(),
           getName(), message);
       if (e != null) {
         e.printStackTrace();

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -102,7 +102,7 @@ public class BulkGetFuture<T>
     throws InterruptedException, ExecutionException {
     Collection<Operation> timedoutOps = new HashSet<Operation>();
     Map<String, T> ret = internalGet(to, unit, timedoutOps);
-    if (timedoutOps.size() > 0) {
+    if (!timedoutOps.isEmpty()) {
       timeout = true;
       LoggerFactory.getLogger(getClass()).warn(
           new CheckedOperationTimeoutException("Operation timed out: ",
@@ -122,7 +122,7 @@ public class BulkGetFuture<T>
     throws InterruptedException, ExecutionException, TimeoutException {
     Collection<Operation> timedoutOps = new HashSet<Operation>();
     Map<String, T> ret = internalGet(to, unit, timedoutOps);
-    if (timedoutOps.size() > 0) {
+    if (!timedoutOps.isEmpty()) {
       this.timeout = true;
       throw new CheckedOperationTimeoutException("Operation timed out.",
           timedoutOps);

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -611,7 +611,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
   }
 
   public final void authComplete() {
-    if (reconnectBlocked != null && reconnectBlocked.size() > 0) {
+    if (reconnectBlocked != null && !reconnectBlocked.isEmpty()) {
       inputQueue.addAll(reconnectBlocked);
     }
     authLatch.countDown();
@@ -620,11 +620,11 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
   public final void setupForAuth() {
     if (shouldAuth) {
       authLatch = new CountDownLatch(1);
-      if (inputQueue.size() > 0) {
+      if (!inputQueue.isEmpty()) {
         reconnectBlocked = new ArrayList<Operation>(inputQueue.size() + 1);
         inputQueue.drainTo(reconnectBlocked);
       }
-      assert (inputQueue.size() == 0);
+      assert (inputQueue.isEmpty());
       setupResend();
     } else {
       authLatch = new CountDownLatch(0);

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
@@ -123,7 +123,7 @@ public class MultiGetOperationImpl extends MultiKeyOperationImpl implements
     getStatusForErrorCode(errorCode, pl);
 
     if (responseOpaque == terminalOpaque) {
-      if (retryKeys.size() > 0) {
+      if (!retryKeys.isEmpty()) {
         transitionState(OperationState.RETRY);
         OperationStatus retryStatus = new OperationStatus(true,
           Integer.toString(retryKeys.size()), StatusCode.ERR_NOT_MY_VBUCKET);

--- a/src/main/java/net/spy/memcached/tapmessage/ResponseMessage.java
+++ b/src/main/java/net/spy/memcached/tapmessage/ResponseMessage.java
@@ -322,7 +322,7 @@ public class ResponseMessage extends BaseMessage {
 
   @Override
   public String toString() {
-    return String.format("Key: %s, Flags: %d, TTL: %d, Size: %d\nValue: %s",
+    return String.format("Key: %s, Flags: %d, TTL: %d, Size: %d%nValue: %s",
       getKey(), getItemFlags(), getTTL(), getValue().length, deserialize());
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2275 printf-style format should not lead to unexpected behavior at runtime
squid:S1155 Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2275
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

Zeeshan
