### PR TITLE
Code Improvements: remove reduntant cast, add static to private functions

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -999,7 +999,7 @@ public class MemcachedConnection extends SpyThread {
    *
    * @param ops the list of operations to cancel.
    */
-  private void cancelOperations(final Collection<Operation> ops) {
+  private static void cancelOperations(final Collection<Operation> ops) {
     for (Operation op : ops) {
       op.cancel();
     }

--- a/src/main/java/net/spy/memcached/TapClient.java
+++ b/src/main/java/net/spy/memcached/TapClient.java
@@ -240,7 +240,7 @@ public class TapClient {
     return ts;
   }
 
-  private void tapAck(TapConnectionProvider conn, MemcachedNode node,
+  private static void tapAck(TapConnectionProvider conn, MemcachedNode node,
       TapOpcode opcode, int opaque, OperationCallback cb) {
     final Operation op = conn.getOpFactory().tapAck(opcode, opaque, cb);
     conn.addTapAckOp(node, op);

--- a/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
+++ b/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
@@ -39,7 +39,7 @@ import java.util.Collection;
  */
 public abstract class BaseOperationFactory implements OperationFactory {
 
-  private String first(Collection<String> keys) {
+  private static String first(Collection<String> keys) {
     return keys.iterator().next();
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/ObserveOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/ObserveOperationImpl.java
@@ -61,7 +61,7 @@ class ObserveOperationImpl extends SingleKeyOperationImpl implements
   protected void decodePayload(byte[] pl) {
     final short  keylen = (short) decodeShort(pl, 2);
     keystate = (byte) decodeByte(pl, keylen+4);
-    retCas = (long) decodeLong(pl, keylen+5);
+    retCas = decodeLong(pl, keylen+5);
     ObserveResponse r = ObserveResponse.valueOf(keystate);
     ((ObserveOperation.Callback) getCallback()).gotData(key, retCas,
         getHandlingNode(), r);

--- a/src/main/java/net/spy/memcached/transcoders/WhalinV1Transcoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/WhalinV1Transcoder.java
@@ -165,7 +165,7 @@ public class WhalinV1Transcoder extends BaseSerializingTranscoder implements
     return Short.valueOf((short) decodeInteger(data).intValue());
   }
 
-  private Byte decodeByte(byte[] in) {
+  private static Byte decodeByte(byte[] in) {
     assert in.length == 2 : "Wrong length for a byte";
     byte value = in[1];
     return Byte.valueOf(value);
@@ -190,12 +190,12 @@ public class WhalinV1Transcoder extends BaseSerializingTranscoder implements
     return Double.valueOf(Double.longBitsToDouble(l.longValue()));
   }
 
-  private Boolean decodeBoolean(byte[] in) {
+  private static Boolean decodeBoolean(byte[] in) {
     assert in.length == 2 : "Wrong length for a boolean";
     return Boolean.valueOf(in[1] == 1);
   }
 
-  private Long decodeLong(byte[] in) {
+  private static Long decodeLong(byte[] in) {
     long rv = 0L;
     for (int idx = 1; idx < in.length; idx++) {
       byte i = in[idx];
@@ -216,14 +216,14 @@ public class WhalinV1Transcoder extends BaseSerializingTranscoder implements
     }
   }
 
-  private byte[] encodeByte(Byte value) {
+  private static byte[] encodeByte(Byte value) {
     byte[] b = new byte[2];
     b[0] = SPECIAL_BYTE;
     b[1] = value.byteValue();
     return b;
   }
 
-  private byte[] encodeBoolean(Boolean value) {
+  private static byte[] encodeBoolean(Boolean value) {
     byte[] b = new byte[2];
     b[0] = SPECIAL_BOOLEAN;
     b[1] = (byte) (value.booleanValue() ? 1 : 0);
@@ -295,7 +295,7 @@ public class WhalinV1Transcoder extends BaseSerializingTranscoder implements
     return result;
   }
 
-  private byte[] encodeNum(long l, int maxBytes) {
+  private static byte[] encodeNum(long l, int maxBytes) {
     byte[] rv = new byte[maxBytes + 1];
 
     for (int i = 0; i < rv.length - 1; i++) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1905 Redundant casts should not be used
squid:S2325 private methods that dont access instance data should be static

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1905
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

Zeeshan
