### PR TITLE
Classes and methods that rely on the default system encoding should not be used

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -56,6 +56,7 @@ import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.Charset;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -943,7 +944,7 @@ public class MemcachedConnection extends SpyThread {
    * @param retryMessage the body of the retry message.
    */
   protected void handleRetryInformation(final byte[] retryMessage) {
-    getLogger().debug("Got RETRY message: " + new String(retryMessage)
+    getLogger().debug("Got RETRY message: " + new String(retryMessage, Charset.forName("UTF-8"))
       + ", but not handled.");
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -24,6 +24,7 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -49,7 +50,7 @@ abstract class BaseGetOpImpl extends OperationImpl {
       "NOT_FOUND", StatusCode.ERR_NOT_FOUND);
   private static final OperationStatus LOCK_ERROR = new OperationStatus(false,
       "LOCK_ERROR", StatusCode.ERR_TEMP_FAIL);
-  private static final byte[] RN_BYTES = "\r\n".getBytes();
+  private static final byte[] RN_BYTES = "\r\n".getBytes(Charset.forName("UTF-8"));
   private final String cmd;
   private final Collection<String> keys;
   private String currentKey = null;
@@ -200,12 +201,12 @@ abstract class BaseGetOpImpl extends OperationImpl {
       size += k.length;
       size++;
     }
-    byte[] e = String.valueOf(exp).getBytes();
+    byte[] e = String.valueOf(exp).getBytes(Charset.forName("UTF-8"));
     if (hasExp) {
       size += e.length + 1;
     }
     ByteBuffer b = ByteBuffer.allocate(size);
-    b.put(cmd.getBytes());
+    b.put(cmd.getBytes(Charset.forName("UTF-8")));
     for (byte[] k : keyBytes) {
       b.put((byte) ' ');
       b.put(k);

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
@@ -23,6 +23,7 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 import net.spy.memcached.ops.FlushOperation;
 import net.spy.memcached.ops.OperationCallback;
@@ -35,7 +36,7 @@ import net.spy.memcached.ops.StatusCode;
  */
 final class FlushOperationImpl extends OperationImpl implements FlushOperation {
 
-  private static final byte[] FLUSH = "flush_all\r\n".getBytes();
+  private static final byte[] FLUSH = "flush_all\r\n".getBytes(Charset.forName("UTF-8"));
 
   private static final OperationStatus OK = new OperationStatus(true, "OK",
     StatusCode.SUCCESS);
@@ -61,7 +62,7 @@ final class FlushOperationImpl extends OperationImpl implements FlushOperation {
       b = ByteBuffer.wrap(FLUSH);
     } else {
       b = ByteBuffer.allocate(32);
-      b.put(("flush_all " + delay + "\r\n").getBytes());
+      b.put(("flush_all " + delay + "\r\n").getBytes(Charset.forName("UTF-8")));
       b.flip();
     }
     setBuffer(b);

--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -25,6 +25,7 @@ package net.spy.memcached.protocol.ascii;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 import net.spy.memcached.KeyUtil;
 import net.spy.memcached.ops.Operation;
@@ -148,7 +149,7 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
           byteBuffer.reset();
           OperationErrorType eType = classifyError(line);
           if (eType != null) {
-            errorMsg = line.getBytes();
+            errorMsg = line.getBytes(Charset.forName("UTF-8"));
             handleError(eType, line);
           } else {
             handleLine(line);

--- a/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
@@ -23,6 +23,7 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import net.spy.memcached.ops.OperationState;
@@ -38,7 +39,7 @@ final class StatsOperationImpl extends OperationImpl implements StatsOperation {
   private static final OperationStatus END = new OperationStatus(true, "END",
     StatusCode.SUCCESS);
 
-  private static final byte[] MSG = "stats\r\n".getBytes();
+  private static final byte[] MSG = "stats\r\n".getBytes(Charset.forName("UTF-8"));
 
   private final byte[] msg;
   private final StatsOperation.Callback cb;
@@ -49,7 +50,7 @@ final class StatsOperationImpl extends OperationImpl implements StatsOperation {
     if (arg == null) {
       msg = MSG;
     } else {
-      msg = ("stats " + arg + "\r\n").getBytes();
+      msg = ("stats " + arg + "\r\n").getBytes(Charset.forName("UTF-8"));
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/TouchOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/TouchOperationImpl.java
@@ -24,6 +24,7 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -72,7 +73,7 @@ final class TouchOperationImpl extends OperationImpl implements TouchOperation {
     ByteBuffer b = null;
     b = ByteBuffer.allocate(KeyUtil.getKeyBytes(key).length
       + String.valueOf(exp).length() + OVERHEAD);
-    b.put(("touch " + key + " " + exp + "\r\n").getBytes());
+    b.put(("touch " + key + " " + exp + "\r\n").getBytes(Charset.forName("UTF-8")));
     b.flip();
     setBuffer(b);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
@@ -23,6 +23,7 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 import net.spy.memcached.ops.NoopOperation;
 import net.spy.memcached.ops.OperationCallback;
@@ -37,7 +38,7 @@ import net.spy.memcached.ops.VersionOperation;
 final class VersionOperationImpl extends OperationImpl implements
     VersionOperation, NoopOperation {
 
-  private static final byte[] REQUEST = "version\r\n".getBytes();
+  private static final byte[] REQUEST = "version\r\n".getBytes(Charset.forName("UTF-8"));
 
   public VersionOperationImpl(OperationCallback c) {
     super(c);

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
@@ -25,6 +25,7 @@ package net.spy.memcached.protocol.binary;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -137,7 +138,7 @@ public class MultiGetOperationImpl extends MultiKeyOperationImpl implements
       retryKeys.add(keys.get(responseOpaque));
     } else if (errorCode != SUCCESS) {
       getLogger().warn("Error on key %s:  %s (%d)", keys.get(responseOpaque),
-          new String(pl), errorCode);
+          new String(pl, Charset.forName("UTF-8")), errorCode);
     } else {
       final int flags = decodeInt(pl, 0);
       final byte[] data = new byte[pl.length - EXTRA_HDR_LEN];

--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -26,6 +26,7 @@ package net.spy.memcached.protocol.binary;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.Charset;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import net.spy.memcached.CASResponse;
@@ -201,7 +202,7 @@ public  abstract class OperationImpl extends BaseOperationImpl
     OperationStatus status = getStatusForErrorCode(errorCode, pl);
 
     if (status == null) {
-      handleError(OperationErrorType.SERVER, new String(pl));
+      handleError(OperationErrorType.SERVER, new String(pl, Charset.forName("UTF-8")));
     } else if (errorCode == SUCCESS) {
       decodePayload(pl);
       transitionState(OperationState.COMPLETE);
@@ -231,17 +232,17 @@ public  abstract class OperationImpl extends BaseOperationImpl
 
         switch (errCode) {
             case ERR_NOT_FOUND:
-                return new CASOperationStatus(false, new String(errPl),
+                return new CASOperationStatus(false, new String(errPl, Charset.forName("UTF-8")),
                         CASResponse.NOT_FOUND, statusCode);
             case ERR_EXISTS:
-                return new CASOperationStatus(false, new String(errPl),
+                return new CASOperationStatus(false, new String(errPl, Charset.forName("UTF-8")),
                         CASResponse.EXISTS, statusCode);
             case ERR_NOT_STORED:
-                return new CASOperationStatus(false, new String(errPl),
+                return new CASOperationStatus(false, new String(errPl, Charset.forName("UTF-8")),
                         CASResponse.NOT_FOUND, statusCode);
             case ERR_2BIG:
             case ERR_INTERNAL:
-                handleError(OperationErrorType.SERVER, new String(errPl));
+                handleError(OperationErrorType.SERVER, new String(errPl, Charset.forName("UTF-8")));
             case ERR_INVAL:
             case ERR_DELTA_BADVAL:
             case ERR_NOT_MY_VBUCKET:
@@ -250,7 +251,7 @@ public  abstract class OperationImpl extends BaseOperationImpl
             case ERR_NOT_SUPPORTED:
             case ERR_BUSY:
             case ERR_TEMP_FAIL:
-                return new OperationStatus(false, new String(errPl), statusCode);
+                return new OperationStatus(false, new String(errPl, Charset.forName("UTF-8")), statusCode);
             default:
                 return null;
         }

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
@@ -24,6 +24,7 @@
 package net.spy.memcached.protocol.binary;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -81,13 +82,13 @@ public abstract class SASLBaseOperationImpl extends OperationImpl {
 
   @Override
   protected void decodePayload(byte[] pl) {
-    getLogger().debug("Auth response:  %s", new String(pl));
+    getLogger().debug("Auth response:  %s", new String(pl, Charset.forName("UTF-8")));
   }
 
   @Override
   protected void finishedPayload(byte[] pl) throws IOException {
     if (errorCode == SASL_CONTINUE) {
-      getCallback().receivedStatus(new OperationStatus(true, new String(pl),
+      getCallback().receivedStatus(new OperationStatus(true, new String(pl, Charset.forName("UTF-8")),
         StatusCode.SUCCESS));
       transitionState(OperationState.COMPLETE);
     } else if (errorCode == 0) {

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
@@ -22,6 +22,8 @@
 
 package net.spy.memcached.protocol.binary;
 
+import java.nio.charset.Charset;
+
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.SASLMechsOperation;
@@ -43,7 +45,7 @@ class SASLMechsOperationImpl extends OperationImpl implements
 
   @Override
   protected void decodePayload(byte[] pl) {
-    getCallback().receivedStatus(new OperationStatus(true, new String(pl),
+    getCallback().receivedStatus(new OperationStatus(true, new String(pl, Charset.forName("UTF-8")),
       StatusCode.SUCCESS));
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
@@ -23,6 +23,8 @@
 
 package net.spy.memcached.protocol.binary;
 
+import java.nio.charset.Charset;
+
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StatusCode;
@@ -43,7 +45,7 @@ class VersionOperationImpl extends OperationImpl implements VersionOperation {
 
   @Override
   protected void decodePayload(byte[] pl) {
-    getCallback().receivedStatus(new OperationStatus(true, new String(pl),
+    getCallback().receivedStatus(new OperationStatus(true, new String(pl, Charset.forName("UTF-8")),
       StatusCode.SUCCESS));
   }
 }

--- a/src/main/java/net/spy/memcached/tapmessage/RequestMessage.java
+++ b/src/main/java/net/spy/memcached/tapmessage/RequestMessage.java
@@ -23,6 +23,7 @@
 package net.spy.memcached.tapmessage;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -167,7 +168,7 @@ public class RequestMessage extends BaseMessage{
       }
       bb.putInt(flag);
     }
-    bb.put(name.getBytes());
+    bb.put(name.getBytes(Charset.forName("UTF-8")));
     if (hasBackfill) {
       bb.putLong(backfilldate);
     }

--- a/src/main/java/net/spy/memcached/tapmessage/ResponseMessage.java
+++ b/src/main/java/net/spy/memcached/tapmessage/ResponseMessage.java
@@ -23,6 +23,7 @@
 package net.spy.memcached.tapmessage;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.LinkedList;
 import java.util.List;
 import net.spy.memcached.CachedData;
@@ -246,7 +247,7 @@ public class ResponseMessage extends BaseMessage {
    * @return The key data.
    */
   public String getKey() {
-    return new String(key);
+    return new String(key, Charset.forName("UTF-8"));
   }
 
   /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

Zeeshan
