### PR TITLE
Code Improvement: collection itteration, invoke performance methods, remove unnecesssary constructor

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1758,7 +1758,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
           // XXX: Potential abstraction leak.
           // The handling of incr/decr in the binary protocol
           // Allows us to avoid string processing.
-          rv.set(new Long(s.isSuccess() ? s.getMessage() : "-1"));
+          rv.set(Long.valueOf(s.isSuccess() ? s.getMessage() : "-1"));
         }
 
         @Override
@@ -1993,7 +1993,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
         new OperationCallback() {
           @Override
           public void receivedStatus(OperationStatus s) {
-            rv.set(new Long(s.isSuccess() ? s.getMessage() : "-1"), s);
+            rv.set(Long.valueOf(s.isSuccess() ? s.getMessage() : "-1"), s);
           }
 
           @Override

--- a/src/main/java/net/spy/memcached/compat/SpyObject.java
+++ b/src/main/java/net/spy/memcached/compat/SpyObject.java
@@ -33,13 +33,6 @@ public class SpyObject extends Object {
   private transient Logger logger = null;
 
   /**
-   * Get an instance of SpyObject.
-   */
-  public SpyObject() {
-    super();
-  }
-
-  /**
    * Get a Logger instance for this class.
    *
    * @return an appropriate logger instance.

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
@@ -72,7 +72,7 @@ public class MultiGetOperationImpl extends MultiKeyOperationImpl implements
       bkeys.put(rv, KeyUtil.getKeyBytes(k));
       rkeys.put(k, rv);
       synchronized (vbmap) {
-        vbmap.put(k, new Short((short) 0));
+        vbmap.put(k, Short.valueOf((short) 0));
       }
     }
     return rv;

--- a/src/main/java/net/spy/memcached/tapmessage/RequestMessage.java
+++ b/src/main/java/net/spy/memcached/tapmessage/RequestMessage.java
@@ -179,9 +179,9 @@ public class RequestMessage extends BaseMessage{
     }
     if (hasVBucketCheckpoints) {
       bb.putShort((short)vBucketCheckpoints.size());
-      for (Short vBucket : vBucketCheckpoints.keySet()) {
-        bb.putShort(vBucket);
-        bb.putLong(vBucketCheckpoints.get(vBucket));
+      for (Map.Entry<Short, Long> vBucket : vBucketCheckpoints.entrySet()){
+    	bb.putShort(vBucket.getKey());
+    	bb.putLong(vBucket.getValue());
       }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 entrySet() should be iterated when both key and value are needed
findbugs:DM_NUMBER_CTOR Performance-Method invokes inefficient Number constructor; use static valueOf instead
pmd:UnnecessaryConstructor Remove all unnecessary constructor

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864 
https://dev.eclipse.org/sonar/coding_rules#q=findbugs:DM_NUMBER_CTOR
https://dev.eclipse.org/sonar/coding_rules#q=pmd:UnnecessaryConstructor

Please let me know if you have any questions.

Zeeshan
