### PR TITLE
Remove Useless parentheses

### DIFF
--- a/src/main/java/net/spy/memcached/compat/SpyObject.java
+++ b/src/main/java/net/spy/memcached/compat/SpyObject.java
@@ -48,6 +48,6 @@ public class SpyObject extends Object {
     if (logger == null) {
       logger = LoggerFactory.getLogger(getClass());
     }
-    return (logger);
+    return logger;
   }
 }

--- a/src/main/java/net/spy/memcached/compat/SpyThread.java
+++ b/src/main/java/net/spy/memcached/compat/SpyThread.java
@@ -59,6 +59,6 @@ public class SpyThread extends Thread {
     if (logger == null) {
       logger = LoggerFactory.getLogger(getClass());
     }
-    return (logger);
+    return logger;
   }
 }

--- a/src/main/java/net/spy/memcached/compat/log/AbstractLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/AbstractLogger.java
@@ -45,7 +45,7 @@ public abstract class AbstractLogger implements Logger {
    * Get the name of this logger.
    */
   public String getName() {
-    return (name);
+    return name;
   }
 
   /**

--- a/src/main/java/net/spy/memcached/compat/log/DefaultLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/DefaultLogger.java
@@ -49,7 +49,7 @@ public class DefaultLogger extends AbstractLogger {
    */
   @Override
   public boolean isTraceEnabled() {
-    return (false);
+    return false;
   }
 
   /**
@@ -57,7 +57,7 @@ public class DefaultLogger extends AbstractLogger {
    */
   @Override
   public boolean isDebugEnabled() {
-    return (false);
+    return false;
   }
 
   /**
@@ -65,7 +65,7 @@ public class DefaultLogger extends AbstractLogger {
    */
   @Override
   public boolean isInfoEnabled() {
-    return (true);
+    return true;
   }
 
   /**

--- a/src/main/java/net/spy/memcached/compat/log/Level.java
+++ b/src/main/java/net/spy/memcached/compat/log/Level.java
@@ -58,6 +58,6 @@ public enum Level {
    */
   @Override
   public String toString() {
-    return ("{LogLevel:  " + name() + "}");
+    return "{LogLevel:  " + name() + "}";
   }
 }

--- a/src/main/java/net/spy/memcached/compat/log/Log4JLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/Log4JLogger.java
@@ -47,17 +47,17 @@ public class Log4JLogger extends AbstractLogger {
 
   @Override
   public boolean isTraceEnabled() {
-    return (l4jLogger.isTraceEnabled());
+    return l4jLogger.isTraceEnabled();
   }
 
   @Override
   public boolean isDebugEnabled() {
-    return (l4jLogger.isDebugEnabled());
+    return l4jLogger.isDebugEnabled();
   }
 
   @Override
   public boolean isInfoEnabled() {
-    return (l4jLogger.isInfoEnabled());
+    return l4jLogger.isInfoEnabled();
   }
 
   /**

--- a/src/main/java/net/spy/memcached/compat/log/LoggerFactory.java
+++ b/src/main/java/net/spy/memcached/compat/log/LoggerFactory.java
@@ -70,7 +70,7 @@ public final class LoggerFactory extends Object {
    * @return a Logger instance
    */
   public static Logger getLogger(Class<?> clazz) {
-    return (getLogger(clazz.getName()));
+    return getLogger(clazz.getName());
   }
 
   /**
@@ -84,7 +84,7 @@ public final class LoggerFactory extends Object {
       throw new NullPointerException("Logger name may not be null.");
     }
     init();
-    return (instance.internalGetLogger(name));
+    return instance.internalGetLogger(name);
   }
 
   // Get an instance of Logger from internal mechanisms.
@@ -105,7 +105,7 @@ public final class LoggerFactory extends Object {
       rv = tmp == null ? newLogger : tmp;
     }
 
-    return (rv);
+    return rv;
   }
 
   private Logger getNewInstance(String name) throws InstantiationException,
@@ -117,7 +117,7 @@ public final class LoggerFactory extends Object {
     Object[] args = { name };
     Logger rv = instanceConstructor.newInstance(args);
 
-    return (rv);
+    return rv;
   }
 
   // Find the appropriate constructor

--- a/src/main/java/net/spy/memcached/compat/log/SunLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/SunLogger.java
@@ -50,17 +50,17 @@ public class SunLogger extends AbstractLogger {
 
   @Override
   public boolean isTraceEnabled() {
-    return (sunLogger.isLoggable(java.util.logging.Level.FINEST));
+    return sunLogger.isLoggable(java.util.logging.Level.FINEST);
   }
 
   @Override
   public boolean isDebugEnabled() {
-    return (sunLogger.isLoggable(java.util.logging.Level.FINE));
+    return sunLogger.isLoggable(java.util.logging.Level.FINE);
   }
 
   @Override
   public boolean isInfoEnabled() {
-    return (sunLogger.isLoggable(java.util.logging.Level.INFO));
+    return sunLogger.isLoggable(java.util.logging.Level.INFO);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -445,7 +445,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
    * @see net.spy.memcached.MemcachedNode#isAuthenticated()
    */
   public boolean isAuthenticated() {
-    return (0 == authLatch.getCount());
+    return 0 == authLatch.getCount();
   }
 
   /*
@@ -624,7 +624,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
         reconnectBlocked = new ArrayList<Operation>(inputQueue.size() + 1);
         inputQueue.drainTo(reconnectBlocked);
       }
-      assert (inputQueue.size() == 0);
+      assert inputQueue.size() == 0;
       setupResend();
     } else {
       authLatch = new CountDownLatch(0);

--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -285,7 +285,7 @@ public  abstract class OperationImpl extends BaseOperationImpl
   }
 
   static int decodeByte(byte[] data, int i) {
-    return (data[i] & 0xff);
+    return data[i] & 0xff;
   }
   static int decodeInt(byte[] data, int i) {
     return (data[i] & 0xff) << 24

--- a/src/main/java/net/spy/memcached/protocol/binary/ReplicaGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/ReplicaGetOperationImpl.java
@@ -54,7 +54,7 @@ public class ReplicaGetOperationImpl extends SingleKeyOperationImpl
   protected void decodePayload(byte[] pl) {
     final int flags = decodeInt(pl, 0);
     final byte[] data = new byte[pl.length - EXTRA_HDR_LEN - keyLen];
-    System.arraycopy(pl, (EXTRA_HDR_LEN + keyLen), data, 0,
+    System.arraycopy(pl, EXTRA_HDR_LEN + keyLen, data, 0,
       pl.length - EXTRA_HDR_LEN - keyLen);
     ReplicaGetOperation.Callback gcb =
       (ReplicaGetOperation.Callback) getCallback();

--- a/src/main/java/net/spy/memcached/protocol/binary/SingleKeyOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SingleKeyOperationImpl.java
@@ -63,14 +63,14 @@ abstract class SingleKeyOperationImpl extends OperationImpl implements
   }
 
   public void setVBucket(String k, short vb) {
-    assert k.equals(key) : (k + " doesn't match the key " + key
-        + " for this operation");
+    assert k.equals(key) : k + " doesn't match the key " + key
+        + " for this operation";
     vbucket = vb;
   }
 
   public short getVBucket(String k) {
-    assert k.equals(key) : (k + " doesn't match the key " + key
-        + " for this operation");
+    assert k.equals(key) : k + " doesn't match the key " + key
+        + " for this operation";
     return vbucket;
   }
 

--- a/src/main/java/net/spy/memcached/tapmessage/ResponseMessage.java
+++ b/src/main/java/net/spy/memcached/tapmessage/ResponseMessage.java
@@ -97,7 +97,7 @@ public class ResponseMessage extends BaseMessage {
       key = new byte[keylength];
       System.arraycopy(b, KEY_OFFSET + engineprivate, key, 0, keylength);
       value = new byte[b.length - keylength - engineprivate - KEY_OFFSET];
-      System.arraycopy(b, (b.length - value.length), value, 0, value.length);
+      System.arraycopy(b, b.length - value.length, value, 0, value.length);
     } else if (opcode.equals(TapOpcode.DELETE)) {
       itemflags = 0;
       itemexpiry = 0;

--- a/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
@@ -39,14 +39,14 @@ public class SerializingTranscoder extends BaseSerializingTranscoder implements
 
   // Special flags for specially handled types.
   private static final int SPECIAL_MASK = 0xff00;
-  static final int SPECIAL_BOOLEAN = (1 << 8);
-  static final int SPECIAL_INT = (2 << 8);
-  static final int SPECIAL_LONG = (3 << 8);
-  static final int SPECIAL_DATE = (4 << 8);
-  static final int SPECIAL_BYTE = (5 << 8);
-  static final int SPECIAL_FLOAT = (6 << 8);
-  static final int SPECIAL_DOUBLE = (7 << 8);
-  static final int SPECIAL_BYTEARRAY = (8 << 8);
+  static final int SPECIAL_BOOLEAN = 1 << 8;
+  static final int SPECIAL_INT = 2 << 8;
+  static final int SPECIAL_LONG = 3 << 8;
+  static final int SPECIAL_DATE = 4 << 8;
+  static final int SPECIAL_BYTE = 5 << 8;
+  static final int SPECIAL_FLOAT = 6 << 8;
+  static final int SPECIAL_DOUBLE = 7 << 8;
+  static final int SPECIAL_BYTEARRAY = 8 << 8;
 
   private final TranscoderUtils tu = new TranscoderUtils(true);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

Zeeshan
