### PR TITLE
String literals should not be duplicated

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -139,7 +139,15 @@ import net.spy.memcached.util.StringUtils;
  */
 public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     ConnectionObserver {
-
+  
+  private static final String EXCEPTION_WAITING_FOR_VALUE = "Exception waiting for value";
+  
+  private static final String INTERRUPTED_WAITING_FOR_VALUE = "Interrupted waiting for value";
+  
+  private static final String TIMEOUT_WAITING_FOR_VALUE = "Timeout waiting for value";
+  
+  private static final String WRONG_KEY_RETURNED = "Wrong key returned";
+	
   protected volatile boolean shuttingDown;
 
   protected final long operationTimeout;
@@ -733,15 +741,15 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
           TimeUnit.MILLISECONDS);
       return casr;
     } catch (InterruptedException e) {
-      throw new RuntimeException("Interrupted waiting for value", e);
+      throw new RuntimeException(INTERRUPTED_WAITING_FOR_VALUE, e);
     } catch (ExecutionException e) {
       if(e.getCause() instanceof CancellationException) {
         throw (CancellationException) e.getCause();
       } else {
-        throw new RuntimeException("Exception waiting for value", e);
+        throw new RuntimeException(EXCEPTION_WAITING_FOR_VALUE, e);
       }
     } catch (TimeoutException e) {
-      throw new OperationTimeoutException("Timeout waiting for value: "
+      throw new OperationTimeoutException(TIMEOUT_WAITING_FOR_VALUE
         + buildTimeoutMessage(operationTimeout, TimeUnit.MILLISECONDS), e);
     }
   }
@@ -1030,7 +1038,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
 
       @Override
       public void gotData(String k, int flags, byte[] data) {
-        assert key.equals(k) : "Wrong key returned";
+        assert key.equals(k) : WRONG_KEY_RETURNED;
         val =
             tcService.decode(tc, new CachedData(flags, data, tc.getMaxSize()));
       }
@@ -1088,7 +1096,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
 
       @Override
       public void gotData(String k, int flags, long cas, byte[] data) {
-        assert key.equals(k) : "Wrong key returned";
+        assert key.equals(k) : WRONG_KEY_RETURNED;
         val =
             new CASValue<T>(cas, tc.decode(new CachedData(flags, data,
                 tc.getMaxSize())));
@@ -1136,15 +1144,15 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     try {
       return asyncGets(key, tc).get(operationTimeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new RuntimeException("Interrupted waiting for value", e);
+      throw new RuntimeException(INTERRUPTED_WAITING_FOR_VALUE, e);
     } catch (ExecutionException e) {
       if(e.getCause() instanceof CancellationException) {
         throw (CancellationException) e.getCause();
       } else {
-        throw new RuntimeException("Exception waiting for value", e);
+        throw new RuntimeException(EXCEPTION_WAITING_FOR_VALUE, e);
       }
     } catch (TimeoutException e) {
-      throw new OperationTimeoutException("Timeout waiting for value", e);
+      throw new OperationTimeoutException(TIMEOUT_WAITING_FOR_VALUE, e);
     }
   }
 
@@ -1168,15 +1176,15 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
       return asyncGetAndTouch(key, exp, tc).get(operationTimeout,
           TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new RuntimeException("Interrupted waiting for value", e);
+      throw new RuntimeException(INTERRUPTED_WAITING_FOR_VALUE, e);
     } catch (ExecutionException e) {
       if(e.getCause() instanceof CancellationException) {
         throw (CancellationException) e.getCause();
       } else {
-        throw new RuntimeException("Exception waiting for value", e);
+        throw new RuntimeException(EXCEPTION_WAITING_FOR_VALUE, e);
       }
     } catch (TimeoutException e) {
-      throw new OperationTimeoutException("Timeout waiting for value", e);
+      throw new OperationTimeoutException(TIMEOUT_WAITING_FOR_VALUE, e);
     }
   }
 
@@ -1229,15 +1237,15 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     try {
       return asyncGet(key, tc).get(operationTimeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
-      throw new RuntimeException("Interrupted waiting for value", e);
+      throw new RuntimeException(INTERRUPTED_WAITING_FOR_VALUE, e);
     } catch (ExecutionException e) {
       if(e.getCause() instanceof CancellationException) {
         throw (CancellationException) e.getCause();
       } else {
-        throw new RuntimeException("Exception waiting for value", e);
+        throw new RuntimeException(EXCEPTION_WAITING_FOR_VALUE, e);
       }
     } catch (TimeoutException e) {
-      throw new OperationTimeoutException("Timeout waiting for value: "
+      throw new OperationTimeoutException(TIMEOUT_WAITING_FOR_VALUE
         + buildTimeoutMessage(operationTimeout, TimeUnit.MILLISECONDS), e);
     }
   }
@@ -1525,7 +1533,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
 
           @Override
           public void gotData(String k, int flags, long cas, byte[] data) {
-            assert k.equals(key) : "Wrong key returned";
+            assert k.equals(key) : WRONG_KEY_RETURNED;
             val =
                 new CASValue<T>(cas, tc.decode(new CachedData(flags, data,
                     tc.getMaxSize())));

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -123,6 +123,8 @@ public class MemcachedConnection extends SpyThread {
     "[MEM] Response Rate: Failure";
   private static final String OVERALL_RESPONSE_SUCC_METRIC =
     "[MEM] Response Rate: Success";
+  private static final String WAKEUP_RETURNED_THE_WRONG_SELECTOR =
+	"Wakeup returned the wrong selector.";
 
   /**
    * If the connection is alread shut down or shutting down.
@@ -1247,7 +1249,7 @@ public class MemcachedConnection extends SpyThread {
     metrics.markMeter(OVERALL_REQUEST_METRIC);
 
     Selector s = selector.wakeup();
-    assert s == selector : "Wakeup returned the wrong selector.";
+    assert s == selector : WAKEUP_RETURNED_THE_WRONG_SELECTOR;
     getLogger().debug("Added %s to %s", o, node);
   }
 
@@ -1269,7 +1271,7 @@ public class MemcachedConnection extends SpyThread {
     metrics.markMeter(OVERALL_REQUEST_METRIC);
 
     Selector s = selector.wakeup();
-    assert s == selector : "Wakeup returned the wrong selector.";
+    assert s == selector : WAKEUP_RETURNED_THE_WRONG_SELECTOR;
     getLogger().debug("Added %s to %s", o, node);
   }
 
@@ -1315,7 +1317,7 @@ public class MemcachedConnection extends SpyThread {
     }
 
     Selector s = selector.wakeup();
-    assert s == selector : "Wakeup returned the wrong selector.";
+    assert s == selector : WAKEUP_RETURNED_THE_WRONG_SELECTOR;
     return latch;
   }
 
@@ -1326,7 +1328,7 @@ public class MemcachedConnection extends SpyThread {
     shutDown = true;
     try {
       Selector s = selector.wakeup();
-      assert s == selector : "Wakeup returned the wrong selector.";
+      assert s == selector : WAKEUP_RETURNED_THE_WRONG_SELECTOR;
       for (MemcachedNode node : locator.getAll()) {
         if (node.getChannel() != null) {
           node.getChannel().close();

--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -62,7 +62,7 @@ public class OperationFuture<T>
   private Operation op;
   private final String key;
   private Long cas;
-
+  private static final String NO_OPERATTION = "No operation";
   /**
    * Create an OperationFuture for a given async operation.
    *
@@ -107,7 +107,7 @@ public class OperationFuture<T>
    * @return true if the operation has not yet been written to the network
    */
   public boolean cancel(boolean ign) {
-    assert op != null : "No operation";
+    assert op != null : NO_OPERATTION;
     op.cancel();
     notifyListeners();
     return op.getState() == OperationState.WRITE_QUEUED;
@@ -119,7 +119,7 @@ public class OperationFuture<T>
    * @return true if the operation has not yet been written to the network
    */
   public boolean cancel() {
-    assert op != null : "No operation";
+    assert op != null : NO_OPERATTION;
     op.cancel();
     notifyListeners();
     return op.getState() == OperationState.WRITE_QUEUED;
@@ -286,7 +286,7 @@ public class OperationFuture<T>
    * @return true if the Operation has been canceled
    */
   public boolean isCancelled() {
-    assert op != null : "No operation";
+    assert op != null : NO_OPERATTION;
     return op.isCancelled();
   }
 
@@ -301,7 +301,7 @@ public class OperationFuture<T>
    * @return true if the Operation is done
    */
   public boolean isDone() {
-    assert op != null : "No operation";
+    assert op != null : NO_OPERATTION;
     return latch.getCount() == 0 || op.isCancelled()
         || op.getState() == OperationState.COMPLETE;
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -66,6 +66,10 @@ import net.spy.memcached.tapmessage.TapOpcode;
  * Operation factory for the ascii protocol.
  */
 public class AsciiOperationFactory extends BaseOperationFactory {
+	
+  private static final String FOR_ASCIII_PROTOCOL = "for ASCII protocol";
+  
+  private static final String TAP_IS_NOT_SUPPORTED_FOR_ASCII_PROTOCOL = "Tap is not supported for ASCII protocol";
 
   public DeleteOperation delete(String key, DeleteOperation.Callback cb) {
     return new DeleteOperationImpl(key, cb);
@@ -74,7 +78,7 @@ public class AsciiOperationFactory extends BaseOperationFactory {
   public DeleteOperation delete(String key, long cas,
     DeleteOperation.Callback cb) {
     throw new UnsupportedOperationException("Delete with CAS is not supported "
-        + "for ASCII protocol");
+        + FOR_ASCIII_PROTOCOL);
   }
 
   public FlushOperation flush(int delay, OperationCallback cb) {
@@ -84,7 +88,7 @@ public class AsciiOperationFactory extends BaseOperationFactory {
   public GetAndTouchOperation getAndTouch(String key, int expiration,
       GetAndTouchOperation.Callback cb) {
     throw new UnsupportedOperationException("Get and touch is not supported "
-        + "for ASCII protocol");
+        + FOR_ASCIII_PROTOCOL);
   }
 
   public GetOperation get(String key, GetOperation.Callback cb) {
@@ -102,7 +106,7 @@ public class AsciiOperationFactory extends BaseOperationFactory {
   public ObserveOperation observe(String key, long casId, int index,
       ObserveOperation.Callback cb) {
     throw new UnsupportedOperationException("Observe is not supported "
-        + "for ASCII protocol");
+        + FOR_ASCIII_PROTOCOL);
   }
 
   public UnlockOperation unlock(String key, long casId,
@@ -116,7 +120,7 @@ public class AsciiOperationFactory extends BaseOperationFactory {
 
   public StatsOperation keyStats(String key, Callback cb) {
     throw new UnsupportedOperationException("Key stats are not supported "
-        + "for ASCII protocol");
+        + FOR_ASCIII_PROTOCOL);
   }
 
   public MutatorOperation mutate(Mutator m, String key, long by, long exp,
@@ -187,41 +191,37 @@ public class AsciiOperationFactory extends BaseOperationFactory {
 
   @Override
   public TapOperation tapBackfill(String id, long date, OperationCallback cb) {
-    throw new UnsupportedOperationException("Tap is not supported for ASCII"
-        + " protocol");
+    throw new UnsupportedOperationException(TAP_IS_NOT_SUPPORTED_FOR_ASCII_PROTOCOL);
   }
 
   @Override
   public TapOperation tapCustom(String id, RequestMessage message,
       OperationCallback cb) {
-    throw new UnsupportedOperationException("Tap is not supported for ASCII"
-        + " protocol");
+    throw new UnsupportedOperationException(TAP_IS_NOT_SUPPORTED_FOR_ASCII_PROTOCOL);
   }
 
   @Override
   public TapOperation tapAck(TapOpcode opcode, int opaque,
       OperationCallback cb) {
-    throw new UnsupportedOperationException("Tap is not supported for ASCII"
-        + " protocol");
+    throw new UnsupportedOperationException(TAP_IS_NOT_SUPPORTED_FOR_ASCII_PROTOCOL);
   }
 
   @Override
   public TapOperation tapDump(String id, OperationCallback cb) {
-    throw new UnsupportedOperationException("Tap is not supported for ASCII"
-        + " protocol");
+    throw new UnsupportedOperationException(TAP_IS_NOT_SUPPORTED_FOR_ASCII_PROTOCOL);
   }
 
   @Override
   public ReplicaGetOperation replicaGet(String key, int index,
   ReplicaGetOperation.Callback callback) {
     throw new UnsupportedOperationException("Replica get is not supported "
-        + "for ASCII protocol");
+        + FOR_ASCIII_PROTOCOL);
   }
 
   @Override
   public ReplicaGetsOperation replicaGets(String key, int index,
     ReplicaGetsOperation.Callback callback) {
     throw new UnsupportedOperationException("Replica gets is not supported "
-      + "for ASCII protocol");
+      + FOR_ASCIII_PROTOCOL);
   }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1192 String literals should not be duplicated

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1192

Please let me know if you have any questions.

Zeeshan
