### PR TITLE
Constant names should comply with a naming convention

### DIFF
--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -72,7 +72,7 @@ public class DefaultConnectionFactory extends SpyObject implements
    * Default failure mode.
    */
   public static final FailureMode DEFAULT_FAILURE_MODE =
-      FailureMode.Redistribute;
+      FailureMode.REDISTRIBUTE;
 
   /**
    * Default hash algorithm.

--- a/src/main/java/net/spy/memcached/FailureMode.java
+++ b/src/main/java/net/spy/memcached/FailureMode.java
@@ -36,7 +36,7 @@ public enum FailureMode {
    * given key.
    * </p>
    */
-  Redistribute,
+  REDISTRIBUTE,
   /**
    * Continue to retry a failing node until it comes back up.
    *
@@ -46,10 +46,10 @@ public enum FailureMode {
    * wait very long for async command completion.
    * </p>
    */
-  Retry,
+  RETRY,
 
   /**
    * Automatically cancel all operations heading towards a downed node.
    */
-  Cancel
+  CANCEL
 }

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -474,7 +474,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public <T> OperationFuture<Boolean> append(long cas, String key, T val,
       Transcoder<T> tc) {
-    return asyncCat(ConcatenationType.append, cas, key, val, tc);
+    return asyncCat(ConcatenationType.APPEND, cas, key, val, tc);
   }
 
   /**
@@ -498,7 +498,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public <T> OperationFuture<Boolean> append(String key, T val,
       Transcoder<T> tc) {
-    return asyncCat(ConcatenationType.append, 0, key, val, tc);
+    return asyncCat(ConcatenationType.APPEND, 0, key, val, tc);
   }
 
   /**
@@ -563,7 +563,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public <T> OperationFuture<Boolean> prepend(long cas, String key, T val,
       Transcoder<T> tc) {
-    return asyncCat(ConcatenationType.prepend, cas, key, val, tc);
+    return asyncCat(ConcatenationType.PREPEND, cas, key, val, tc);
   }
 
   /**
@@ -584,7 +584,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public <T> OperationFuture<Boolean> prepend(String key, T val,
       Transcoder<T> tc) {
-    return asyncCat(ConcatenationType.prepend, 0, key, val, tc);
+    return asyncCat(ConcatenationType.PREPEND, 0, key, val, tc);
   }
 
   /**
@@ -626,7 +626,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     final OperationFuture<CASResponse> rv =
       new OperationFuture<CASResponse>(key, latch, operationTimeout,
       executorService);
-    Operation op = opFact.cas(StoreType.set, key, casId, co.getFlags(), exp,
+    Operation op = opFact.cas(StoreType.SET, key, casId, co.getFlags(), exp,
         co.getData(), new StoreOperation.Callback() {
             @Override
             public void receivedStatus(OperationStatus val) {
@@ -816,7 +816,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public <T> OperationFuture<Boolean> add(String key, int exp, T o,
       Transcoder<T> tc) {
-    return asyncStore(StoreType.add, key, exp, o, tc);
+    return asyncStore(StoreType.ADD, key, exp, o, tc);
   }
 
   /**
@@ -852,7 +852,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public OperationFuture<Boolean> add(String key, int exp, Object o) {
-    return asyncStore(StoreType.add, key, exp, o, transcoder);
+    return asyncStore(StoreType.ADD, key, exp, o, transcoder);
   }
 
   /**
@@ -890,7 +890,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public <T> OperationFuture<Boolean> set(String key, int exp, T o,
       Transcoder<T> tc) {
-    return asyncStore(StoreType.set, key, exp, o, tc);
+    return asyncStore(StoreType.SET, key, exp, o, tc);
   }
 
   /**
@@ -926,7 +926,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public OperationFuture<Boolean> set(String key, int exp, Object o) {
-    return asyncStore(StoreType.set, key, exp, o, transcoder);
+    return asyncStore(StoreType.SET, key, exp, o, transcoder);
   }
 
   /**
@@ -965,7 +965,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public <T> OperationFuture<Boolean> replace(String key, int exp, T o,
       Transcoder<T> tc) {
-    return asyncStore(StoreType.replace, key, exp, o, tc);
+    return asyncStore(StoreType.REPLACE, key, exp, o, tc);
   }
 
   /**
@@ -1001,7 +1001,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public OperationFuture<Boolean> replace(String key, int exp, Object o) {
-    return asyncStore(StoreType.replace, key, exp, o, transcoder);
+    return asyncStore(StoreType.REPLACE, key, exp, o, transcoder);
   }
 
   /**
@@ -1795,7 +1795,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long incr(String key, long by) {
-    return mutate(Mutator.incr, key, by, 0, -1);
+    return mutate(Mutator.INCR, key, by, 0, -1);
   }
 
   /**
@@ -1815,7 +1815,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long incr(String key, int by) {
-    return mutate(Mutator.incr, key, by, 0, -1);
+    return mutate(Mutator.INCR, key, by, 0, -1);
   }
 
   /**
@@ -1835,7 +1835,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long decr(String key, long by) {
-    return mutate(Mutator.decr, key, by, 0, -1);
+    return mutate(Mutator.DECR, key, by, 0, -1);
   }
 
   /**
@@ -1855,7 +1855,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long decr(String key, int by) {
-    return mutate(Mutator.decr, key, by, 0, -1);
+    return mutate(Mutator.DECR, key, by, 0, -1);
   }
 
   /**
@@ -1877,7 +1877,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long incr(String key, long by, long def, int exp) {
-    return mutateWithDefault(Mutator.incr, key, by, def, exp);
+    return mutateWithDefault(Mutator.INCR, key, by, def, exp);
   }
 
   /**
@@ -1899,7 +1899,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long incr(String key, int by, long def, int exp) {
-    return mutateWithDefault(Mutator.incr, key, by, def, exp);
+    return mutateWithDefault(Mutator.INCR, key, by, def, exp);
   }
 
   /**
@@ -1921,7 +1921,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long decr(String key, long by, long def, int exp) {
-    return mutateWithDefault(Mutator.decr, key, by, def, exp);
+    return mutateWithDefault(Mutator.DECR, key, by, def, exp);
   }
 
   /**
@@ -1943,7 +1943,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long decr(String key, int by, long def, int exp) {
-    return mutateWithDefault(Mutator.decr, key, by, def, exp);
+    return mutateWithDefault(Mutator.DECR, key, by, def, exp);
   }
 
   private long mutateWithDefault(Mutator t, String key, long by, long def,
@@ -1952,7 +1952,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     // The ascii protocol doesn't support defaults, so I added them
     // manually here.
     if (rv == -1) {
-      Future<Boolean> f = asyncStore(StoreType.add, key, exp,
+      Future<Boolean> f = asyncStore(StoreType.ADD, key, exp,
           String.valueOf(def));
       try {
         if (f.get(operationTimeout, TimeUnit.MILLISECONDS)) {
@@ -2018,7 +2018,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public OperationFuture<Long> asyncIncr(String key, long by) {
-    return asyncMutate(Mutator.incr, key, by, 0, -1);
+    return asyncMutate(Mutator.INCR, key, by, 0, -1);
   }
 
   /**
@@ -2032,7 +2032,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public OperationFuture<Long> asyncIncr(String key, int by) {
-    return asyncMutate(Mutator.incr, key, by, 0, -1);
+    return asyncMutate(Mutator.INCR, key, by, 0, -1);
   }
 
   /**
@@ -2046,7 +2046,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public OperationFuture<Long> asyncDecr(String key, long by) {
-    return asyncMutate(Mutator.decr, key, by, 0, -1);
+    return asyncMutate(Mutator.DECR, key, by, 0, -1);
   }
 
   /**
@@ -2060,7 +2060,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public OperationFuture<Long> asyncDecr(String key, int by) {
-    return asyncMutate(Mutator.decr, key, by, 0, -1);
+    return asyncMutate(Mutator.DECR, key, by, 0, -1);
   }
 
   /**
@@ -2077,7 +2077,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public OperationFuture<Long> asyncIncr(String key, long by, long def,
     int exp) {
-    return asyncMutate(Mutator.incr, key, by, def, exp);
+    return asyncMutate(Mutator.INCR, key, by, def, exp);
   }
 
   /**
@@ -2094,7 +2094,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public OperationFuture<Long> asyncIncr(String key, int by, long def,
     int exp) {
-    return asyncMutate(Mutator.incr, key, by, def, exp);
+    return asyncMutate(Mutator.INCR, key, by, def, exp);
   }
 
   /**
@@ -2111,7 +2111,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public OperationFuture<Long> asyncDecr(String key, long by, long def,
     int exp) {
-    return asyncMutate(Mutator.decr, key, by, def, exp);
+    return asyncMutate(Mutator.DECR, key, by, def, exp);
   }
 
   /**
@@ -2128,7 +2128,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public OperationFuture<Long> asyncDecr(String key, int by, long def,
     int exp) {
-    return asyncMutate(Mutator.decr, key, by, def, exp);
+    return asyncMutate(Mutator.DECR, key, by, def, exp);
   }
 
   /**
@@ -2143,7 +2143,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public OperationFuture<Long> asyncIncr(String key, long by, long def) {
-    return asyncMutate(Mutator.incr, key, by, def, 0);
+    return asyncMutate(Mutator.INCR, key, by, def, 0);
   }
 
   /**
@@ -2158,7 +2158,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public OperationFuture<Long> asyncIncr(String key, int by, long def) {
-    return asyncMutate(Mutator.incr, key, by, def, 0);
+    return asyncMutate(Mutator.INCR, key, by, def, 0);
   }
 
   /**
@@ -2173,7 +2173,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public OperationFuture<Long> asyncDecr(String key, long by, long def) {
-    return asyncMutate(Mutator.decr, key, by, def, 0);
+    return asyncMutate(Mutator.DECR, key, by, def, 0);
   }
 
   /**
@@ -2188,7 +2188,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public OperationFuture<Long> asyncDecr(String key, int by, long def) {
-    return asyncMutate(Mutator.decr, key, by, def, 0);
+    return asyncMutate(Mutator.DECR, key, by, def, 0);
   }
 
   /**
@@ -2205,7 +2205,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long incr(String key, long by, long def) {
-    return mutateWithDefault(Mutator.incr, key, by, def, 0);
+    return mutateWithDefault(Mutator.INCR, key, by, def, 0);
   }
 
   /**
@@ -2222,7 +2222,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long incr(String key, int by, long def) {
-    return mutateWithDefault(Mutator.incr, key, by, def, 0);
+    return mutateWithDefault(Mutator.INCR, key, by, def, 0);
   }
 
   /**
@@ -2239,7 +2239,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long decr(String key, long by, long def) {
-    return mutateWithDefault(Mutator.decr, key, by, def, 0);
+    return mutateWithDefault(Mutator.DECR, key, by, def, 0);
   }
 
   /**
@@ -2256,7 +2256,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
    */
   @Override
   public long decr(String key, int by, long def) {
-    return mutateWithDefault(Mutator.decr, key, by, def, 0);
+    return mutateWithDefault(Mutator.DECR, key, by, def, 0);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -987,9 +987,9 @@ public class MemcachedConnection extends SpyThread {
     metrics.incrementCounter(RECON_QUEUE_METRIC);
 
     node.setupResend();
-    if (failureMode == FailureMode.Redistribute) {
+    if (failureMode == FailureMode.REDISTRIBUTE) {
       redistributeOperations(node.destroyInputQueue());
-    } else if (failureMode == FailureMode.Cancel) {
+    } else if (failureMode == FailureMode.CANCEL) {
       cancelOperations(node.destroyInputQueue());
     }
   }
@@ -1204,9 +1204,9 @@ public class MemcachedConnection extends SpyThread {
     MemcachedNode placeIn = null;
     MemcachedNode primary = locator.getPrimary(key);
 
-    if (primary.isActive() || failureMode == FailureMode.Retry) {
+    if (primary.isActive() || failureMode == FailureMode.RETRY) {
       placeIn = primary;
-    } else if (failureMode == FailureMode.Cancel) {
+    } else if (failureMode == FailureMode.CANCEL) {
       o.cancel();
     } else {
       Iterator<MemcachedNode> i = locator.getSequence(key);

--- a/src/main/java/net/spy/memcached/ops/ConcatenationType.java
+++ b/src/main/java/net/spy/memcached/ops/ConcatenationType.java
@@ -29,9 +29,9 @@ public enum ConcatenationType {
   /**
    * Concatenate supplied data to the end of the existing data.
    */
-  append,
+  APPEND,
   /**
    * Concatenate existing data onto the end of the supplied data.
    */
-  prepend
+  PREPEND
 }

--- a/src/main/java/net/spy/memcached/ops/Mutator.java
+++ b/src/main/java/net/spy/memcached/ops/Mutator.java
@@ -29,9 +29,9 @@ public enum Mutator {
   /**
    * Increment a value on the memcached server.
    */
-  incr,
+  INCR,
   /**
    * Decrement a value on the memcached server.
    */
-  decr
+  DECR
 }

--- a/src/main/java/net/spy/memcached/ops/StoreType.java
+++ b/src/main/java/net/spy/memcached/ops/StoreType.java
@@ -29,15 +29,15 @@ public enum StoreType {
   /**
    * Unconditionally store a value in the cache.
    */
-  set,
+  SET,
   /**
    * Store a value in the cache iff there is not already something stored for
    * the given key.
    */
-  add,
+  ADD,
   /**
    * Store a value in the cache iff there is already something stored for the
    * given key.
    */
-  replace
+  REPLACE
 }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -343,7 +343,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     try {
       if (!authLatch.await(authWaitTime, TimeUnit.MILLISECONDS)) {
         FailureMode mode = connectionFactory.getFailureMode();
-        if (mode == FailureMode.Redistribute || mode == FailureMode.Retry) {
+        if (mode == FailureMode.REDISTRIBUTE || mode == FailureMode.RETRY) {
           getLogger().debug("Redistributing Operation " + op + " because auth "
             + "latch taken longer than " + authWaitTime + " milliseconds to "
             + "complete on node " + getSocketAddress());

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -108,7 +108,7 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
   }
 
   public StoreType getStoreType() {
-    return StoreType.set;
+    return StoreType.SET;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/binary/ConcatenationOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/ConcatenationOperationImpl.java
@@ -40,10 +40,10 @@ class ConcatenationOperationImpl extends SingleKeyOperationImpl implements
   private static byte cmdMap(ConcatenationType t) {
     byte rv;
     switch (t) {
-    case append:
+    case APPEND:
       rv = APPEND;
       break;
-    case prepend:
+    case PREPEND:
       rv = PREPEND;
       break;
     default:

--- a/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
@@ -42,7 +42,7 @@ class MutatorOperationImpl extends SingleKeyOperationImpl implements
 
   public MutatorOperationImpl(Mutator m, String k, long b, long d, int e,
       OperationCallback cb) {
-    super(m == Mutator.incr ? CMD_INCR : CMD_DECR, generateOpaque(), k, cb);
+    super(m == Mutator.INCR ? CMD_INCR : CMD_DECR, generateOpaque(), k, cb);
     assert d >= 0 : "Default value is below zero";
     mutator = m;
     by = b;

--- a/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
@@ -132,13 +132,13 @@ public class OptimizedSetImpl extends MultiKeyOperationImpl {
   private static byte cmdMap(StoreType t) {
     byte rv;
     switch (t) {
-    case set:
+    case SET:
       rv = StoreOperationImpl.SETQ;
       break;
-    case add:
+    case ADD:
       rv = StoreOperationImpl.ADDQ;
       break;
-    case replace:
+    case REPLACE:
       rv = StoreOperationImpl.REPLACEQ;
       break;
     default:

--- a/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
@@ -50,13 +50,13 @@ class StoreOperationImpl extends SingleKeyOperationImpl implements
   private static byte cmdMap(StoreType t) {
     byte rv;
     switch (t) {
-    case set:
+    case SET:
       rv = SET;
       break;
-    case add:
+    case ADD:
       rv = ADD;
       break;
-    case replace:
+    case REPLACE:
       rv = REPLACE;
       break;
     default:

--- a/src/test/java/net/spy/memcached/BinaryCancellationTest.java
+++ b/src/test/java/net/spy/memcached/BinaryCancellationTest.java
@@ -32,7 +32,7 @@ public class BinaryCancellationTest extends CancellationBaseCase {
     initClient(new BinaryConnectionFactory() {
       @Override
       public FailureMode getFailureMode() {
-        return FailureMode.Retry;
+        return FailureMode.RETRY;
       }
     });
   }

--- a/src/test/java/net/spy/memcached/BinaryClientTest.java
+++ b/src/test/java/net/spy/memcached/BinaryClientTest.java
@@ -47,7 +47,7 @@ public class BinaryClientTest extends ProtocolBaseCase {
 
       @Override
       public FailureMode getFailureMode() {
-        return FailureMode.Retry;
+        return FailureMode.RETRY;
       }
     });
   }

--- a/src/test/java/net/spy/memcached/CancelFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/CancelFailureModeTest.java
@@ -59,7 +59,7 @@ public class CancelFailureModeTest extends ClientBaseCase {
     initClient(new DefaultConnectionFactory() {
       @Override
       public FailureMode getFailureMode() {
-        return FailureMode.Cancel;
+        return FailureMode.CANCEL;
       }
     });
   }

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -48,7 +48,7 @@ public abstract class ClientBaseCase extends TestCase {
 
       @Override
       public FailureMode getFailureMode() {
-        return FailureMode.Retry;
+        return FailureMode.RETRY;
       }
     });
   }

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -129,7 +129,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
           "password"));
 
     ConnectionFactory f = b.setDaemon(true).setShouldOptimize(false)
-        .setFailureMode(FailureMode.Redistribute)
+        .setFailureMode(FailureMode.REDISTRIBUTE)
         .setHashAlg(DefaultHashAlgorithm.KETAMA_HASH)
         .setInitialObservers(Collections.singleton(testObserver))
         .setOpFact(new BinaryOperationFactory()).setOpTimeout(4225)
@@ -146,7 +146,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
     assertEquals(19, f.getReadBufSize());
     assertSame(DefaultHashAlgorithm.KETAMA_HASH, f.getHashAlg());
     assertTrue(f.getDefaultTranscoder() instanceof WhalinTranscoder);
-    assertSame(FailureMode.Redistribute, f.getFailureMode());
+    assertSame(FailureMode.REDISTRIBUTE, f.getFailureMode());
     assertEquals(1, f.getInitialObservers().size());
     assertSame(testObserver, f.getInitialObservers().iterator().next());
     assertTrue(f.getOperationFactory() instanceof BinaryOperationFactory);

--- a/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
@@ -50,7 +50,7 @@ public class MemcachedConnectionTest extends TestCase {
     Collection<ConnectionObserver> observers =
       new ArrayList<ConnectionObserver>();
     MemcachedConnection mcc = new MemcachedConnection(10240, factory, addresses,
-      observers, FailureMode.Retry, new BinaryOperationFactory());
+      observers, FailureMode.RETRY, new BinaryOperationFactory());
     assertNotNull(mcc.connectionsStatus());
   }
 
@@ -69,7 +69,7 @@ public class MemcachedConnectionTest extends TestCase {
     nodes.add((InetSocketAddress)node.getSocketAddress());
 
     MemcachedConnection conn = new MemcachedConnection(
-      100, factory, nodes, observers, FailureMode.Retry, opfactory);
+      100, factory, nodes, observers, FailureMode.RETRY, opfactory);
     assertTrue(conn.belongsToCluster(node));
     assertFalse(conn.belongsToCluster(node2));
   }

--- a/src/test/java/net/spy/memcached/OperationFactoryTestBase.java
+++ b/src/test/java/net/spy/memcached/OperationFactoryTestBase.java
@@ -118,7 +118,7 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
   }
 
   public void testCASOperationCloning() {
-    CASOperation op = ofact.cas(StoreType.set, "someKey", 727582, 8174, 7175,
+    CASOperation op = ofact.cas(StoreType.SET, "someKey", 727582, 8174, 7175,
       testData, storeCallback);
 
     CASOperation op2 = cloneOne(CASOperation.class, op);
@@ -134,7 +134,7 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
     int exp = 823862;
     long def = 28775;
     long by = 7735;
-    MutatorOperation op = ofact.mutate(Mutator.incr, TEST_KEY, by, def, exp,
+    MutatorOperation op = ofact.mutate(Mutator.INCR, TEST_KEY, by, def, exp,
       genericCallback);
 
     MutatorOperation op2 = cloneOne(MutatorOperation.class, op);
@@ -142,7 +142,7 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
     assertEquals(exp, op2.getExpiration());
     assertEquals(def, op2.getDefault());
     assertEquals(by, op2.getBy());
-    assertSame(Mutator.incr, op2.getType());
+    assertSame(Mutator.INCR, op2.getType());
     assertCallback(op2);
   }
 
@@ -150,7 +150,7 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
     int exp = 823862;
     long def = 28775;
     long by = 7735;
-    MutatorOperation op = ofact.mutate(Mutator.decr, TEST_KEY, by, def, exp,
+    MutatorOperation op = ofact.mutate(Mutator.DECR, TEST_KEY, by, def, exp,
         genericCallback);
 
     MutatorOperation op2 = cloneOne(MutatorOperation.class, op);
@@ -158,57 +158,57 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
     assertEquals(exp, op2.getExpiration());
     assertEquals(def, op2.getDefault());
     assertEquals(by, op2.getBy());
-    assertSame(Mutator.decr, op2.getType());
+    assertSame(Mutator.DECR, op2.getType());
     assertCallback(op2);
   }
 
   public void testStoreOperationAddCloning() {
     int exp = 823862;
     int flags = 7735;
-    StoreOperation op = ofact.store(StoreType.add, TEST_KEY, flags, exp,
+    StoreOperation op = ofact.store(StoreType.ADD, TEST_KEY, flags, exp,
         testData, storeCallback);
 
     StoreOperation op2 = cloneOne(StoreOperation.class, op);
     assertKey(op2);
     assertEquals(exp, op2.getExpiration());
     assertEquals(flags, op2.getFlags());
-    assertSame(StoreType.add, op2.getStoreType());
+    assertSame(StoreType.ADD, op2.getStoreType());
     assertStoreCallback(op2);
   }
 
   public void testStoreOperationSetCloning() {
     int exp = 823862;
     int flags = 7735;
-    StoreOperation op = ofact.store(StoreType.set, TEST_KEY, flags, exp,
+    StoreOperation op = ofact.store(StoreType.SET, TEST_KEY, flags, exp,
         testData, storeCallback);
 
     StoreOperation op2 = cloneOne(StoreOperation.class, op);
     assertKey(op2);
     assertEquals(exp, op2.getExpiration());
     assertEquals(flags, op2.getFlags());
-    assertSame(StoreType.set, op2.getStoreType());
+    assertSame(StoreType.SET, op2.getStoreType());
     assertStoreCallback(op2);
   }
 
   public void testConcatenationOperationAppendCloning() {
     long casId = 82757248;
-    ConcatenationOperation op = ofact.cat(ConcatenationType.append, casId,
+    ConcatenationOperation op = ofact.cat(ConcatenationType.APPEND, casId,
         TEST_KEY, testData, genericCallback);
 
     ConcatenationOperation op2 = cloneOne(ConcatenationOperation.class, op);
     assertKey(op2);
-    assertSame(ConcatenationType.append, op2.getStoreType());
+    assertSame(ConcatenationType.APPEND, op2.getStoreType());
     assertCallback(op2);
   }
 
   public void testConcatenationOperationPrependCloning() {
     long casId = 82757248;
-    ConcatenationOperation op = ofact.cat(ConcatenationType.prepend, casId,
+    ConcatenationOperation op = ofact.cat(ConcatenationType.PREPEND, casId,
         TEST_KEY, testData, genericCallback);
 
     ConcatenationOperation op2 = cloneOne(ConcatenationOperation.class, op);
     assertKey(op2);
-    assertSame(ConcatenationType.prepend, op2.getStoreType());
+    assertSame(ConcatenationType.PREPEND, op2.getStoreType());
     assertCallback(op2);
   }
 

--- a/src/test/java/net/spy/memcached/RedistributeFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/RedistributeFailureModeTest.java
@@ -61,7 +61,7 @@ public class RedistributeFailureModeTest extends ClientBaseCase {
     initClient(new DefaultConnectionFactory() {
       @Override
       public FailureMode getFailureMode() {
-        return FailureMode.Redistribute;
+        return FailureMode.REDISTRIBUTE;
       }
     });
   }

--- a/src/test/java/net/spy/memcached/TimeoutNowriteTest.java
+++ b/src/test/java/net/spy/memcached/TimeoutNowriteTest.java
@@ -51,7 +51,7 @@ public class TimeoutNowriteTest extends ClientBaseCase {
 
       @Override
       public FailureMode getFailureMode() {
-        return FailureMode.Retry;
+        return FailureMode.RETRY;
       }
     }, AddrUtil.getAddresses(TestConfig.IPV4_ADDR + ":"
          + TestConfig.PORT_NUMBER));

--- a/src/test/java/net/spy/memcached/TimeoutTest.java
+++ b/src/test/java/net/spy/memcached/TimeoutTest.java
@@ -44,7 +44,7 @@ public class TimeoutTest extends ClientBaseCase {
 
       @Override
       public FailureMode getFailureMode() {
-        return FailureMode.Retry;
+        return FailureMode.RETRY;
       }
     }, AddrUtil.getAddresses(TestConfig.IPV4_ADDR + ":64213"));
   }

--- a/src/test/java/net/spy/memcached/WokenUpOnIdleTest.java
+++ b/src/test/java/net/spy/memcached/WokenUpOnIdleTest.java
@@ -51,7 +51,7 @@ public class WokenUpOnIdleTest {
       new BinaryConnectionFactory(),
       Arrays.asList(new InetSocketAddress(11211)),
       Collections.<ConnectionObserver>emptyList(),
-      FailureMode.Redistribute,
+      FailureMode.REDISTRIBUTE,
       new BinaryOperationFactory()
     );
 

--- a/src/test/java/net/spy/memcached/protocol/ascii/AsciiToStringTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/AsciiToStringTest.java
@@ -33,7 +33,7 @@ import net.spy.memcached.ops.StoreType;
 public class AsciiToStringTest extends TestCase{
 
   public void testConcatentaion() {
-    (new ConcatenationOperationImpl(ConcatenationType.append, "key",
+    (new ConcatenationOperationImpl(ConcatenationType.APPEND, "key",
         "value".getBytes(), null)).toString();
   }
 
@@ -66,7 +66,7 @@ public class AsciiToStringTest extends TestCase{
   }
 
   public void testMutator() {
-    (new MutatorOperationImpl(Mutator.decr, "key", 1, null)).toString();
+    (new MutatorOperationImpl(Mutator.DECR, "key", 1, null)).toString();
   }
 
   public void testOptimizedGet() {
@@ -78,7 +78,7 @@ public class AsciiToStringTest extends TestCase{
   }
 
   public void testStore() {
-    (new StoreOperationImpl(StoreType.set, "key", 0, 10,
+    (new StoreOperationImpl(StoreType.SET, "key", 0, 10,
         "value".getBytes(), null)).toString();
   }
 

--- a/src/test/java/net/spy/memcached/protocol/ascii/OperationFactoryTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/OperationFactoryTest.java
@@ -42,7 +42,7 @@ public class OperationFactoryTest extends OperationFactoryTestBase {
     int exp = 823862;
     long def = 28775;
     long by = 7735;
-    MutatorOperation op = ofact.mutate(Mutator.incr, TEST_KEY, by, def, exp,
+    MutatorOperation op = ofact.mutate(Mutator.INCR, TEST_KEY, by, def, exp,
         genericCallback);
 
     MutatorOperation op2 = cloneOne(MutatorOperation.class, op);
@@ -50,7 +50,7 @@ public class OperationFactoryTest extends OperationFactoryTestBase {
     assertEquals(-1, op2.getExpiration());
     assertEquals(-1, op2.getDefault());
     assertEquals(by, op2.getBy());
-    assertSame(Mutator.incr, op2.getType());
+    assertSame(Mutator.INCR, op2.getType());
     assertCallback(op2);
   }
 
@@ -59,7 +59,7 @@ public class OperationFactoryTest extends OperationFactoryTestBase {
     int exp = 823862;
     long def = 28775;
     long by = 7735;
-    MutatorOperation op = ofact.mutate(Mutator.decr, TEST_KEY, by, def, exp,
+    MutatorOperation op = ofact.mutate(Mutator.DECR, TEST_KEY, by, def, exp,
         genericCallback);
 
     MutatorOperation op2 = cloneOne(MutatorOperation.class, op);
@@ -67,7 +67,7 @@ public class OperationFactoryTest extends OperationFactoryTestBase {
     assertEquals(-1, op2.getExpiration());
     assertEquals(-1, op2.getDefault());
     assertEquals(by, op2.getBy());
-    assertSame(Mutator.decr, op2.getType());
+    assertSame(Mutator.DECR, op2.getType());
     assertCallback(op2);
   }
 }

--- a/src/test/java/net/spy/memcached/protocol/binary/BinaryToStringTest.java
+++ b/src/test/java/net/spy/memcached/protocol/binary/BinaryToStringTest.java
@@ -38,7 +38,7 @@ import net.spy.memcached.tapmessage.TapOpcode;
 public class BinaryToStringTest extends TestCase {
 
   public void testConcatenation() {
-    (new ConcatenationOperationImpl(ConcatenationType.append, "key",
+    (new ConcatenationOperationImpl(ConcatenationType.APPEND, "key",
         "value".getBytes(), 0, null)).toString();
   }
 
@@ -71,7 +71,7 @@ public class BinaryToStringTest extends TestCase {
   }
 
   public void testMutator() {
-    (new MutatorOperationImpl(Mutator.decr, "key", 1, 0, 15, null)).toString();
+    (new MutatorOperationImpl(Mutator.DECR, "key", 1, 0, 15, null)).toString();
   }
 
   public void testNoop() {
@@ -83,7 +83,7 @@ public class BinaryToStringTest extends TestCase {
   }
 
   public void testOptimiedSet() {
-    (new OptimizedSetImpl(new StoreOperationImpl(StoreType.set, "key", 0, 10,
+    (new OptimizedSetImpl(new StoreOperationImpl(StoreType.SET, "key", 0, 10,
         "value".getBytes(), 0, null))).toString();
   }
 
@@ -104,7 +104,7 @@ public class BinaryToStringTest extends TestCase {
   }
 
   public void testStore() {
-    (new StoreOperationImpl(StoreType.set, "key", 0, 10,
+    (new StoreOperationImpl(StoreType.SET, "key", 0, 10,
         "value".getBytes(), 0, null)).toString();
   }
 

--- a/src/test/java/net/spy/memcached/spring/MemcachedClientFactoryBeanTest.java
+++ b/src/test/java/net/spy/memcached/spring/MemcachedClientFactoryBeanTest.java
@@ -46,7 +46,7 @@ public class MemcachedClientFactoryBeanTest extends TestCase {
   public void testGetObject() throws Exception {
     final MemcachedClientFactoryBean factory = new MemcachedClientFactoryBean();
     factory.setDaemon(true);
-    factory.setFailureMode(FailureMode.Cancel);
+    factory.setFailureMode(FailureMode.CANCEL);
     factory.setHashAlg(DefaultHashAlgorithm.CRC_HASH);
     factory.setProtocol(Protocol.BINARY);
     factory.setServers(TestConfig.IPV4_ADDR + ":22211 " + TestConfig.IPV4_ADDR


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00115 Constant names should comply with a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S00115

Please let me know if you have any questions.

Zeeshan
