### PR TITLE
Malicious code vulnerability may expose internal representation by incorporating reference to mutable object

### DIFF
--- a/src/main/java/net/spy/memcached/CachedData.java
+++ b/src/main/java/net/spy/memcached/CachedData.java
@@ -57,14 +57,14 @@ public final class CachedData {
           + " byte object)");
     }
     flags = f;
-    data = d;
+    data = d == null ? null : d.clone();
   }
 
   /**
    * Get the stored data.
    */
   public byte[] getData() {
-    return data;
+    return data == null ? null : data.clone();
   }
 
   /**

--- a/src/main/java/net/spy/memcached/auth/AuthDescriptor.java
+++ b/src/main/java/net/spy/memcached/auth/AuthDescriptor.java
@@ -53,7 +53,7 @@ public class AuthDescriptor {
    * @param h the callback handler for grabbing credentials and stuff
    */
   public AuthDescriptor(String[] m, CallbackHandler h) {
-    mechs = m;
+    mechs = m == null ? null : m.clone();
     cbh = h;
     authAttempts = 0;
     String authThreshhold =
@@ -91,7 +91,7 @@ public class AuthDescriptor {
   }
 
   public String[] getMechs() {
-    return mechs;
+    return mechs == null ? null : mechs.clone();
   }
 
   public CallbackHandler getCallback() {

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
@@ -52,8 +52,8 @@ public abstract class SASLBaseOperationImpl extends OperationImpl {
   public SASLBaseOperationImpl(byte c, String[] m, byte[] ch, String s,
       Map<String, ?> p, CallbackHandler h, OperationCallback cb) {
     super(c, generateOpaque(), cb);
-    mech = m;
-    challenge = ch;
+    mech = m == null ? null : m.clone();
+    challenge = ch == null ? null : ch.clone();
     serverName = s;
     props = p;
     cbh = h;

--- a/src/main/java/net/spy/memcached/tapmessage/RequestMessage.java
+++ b/src/main/java/net/spy/memcached/tapmessage/RequestMessage.java
@@ -114,7 +114,7 @@ public class RequestMessage extends BaseMessage{
     int oldSize = (vblist.length + 1) * 2;
     int newSize = (vbs.length + 1) * 2;
     totalbody += newSize - oldSize;
-    vblist = vbs;
+    vblist = vbs == null ? null : vbs.clone();
   }
 
   /**

--- a/src/main/java/net/spy/memcached/tapmessage/ResponseMessage.java
+++ b/src/main/java/net/spy/memcached/tapmessage/ResponseMessage.java
@@ -256,7 +256,7 @@ public class ResponseMessage extends BaseMessage {
    * @return The value data.
    */
   public byte[] getValue() {
-    return value;
+    return value == null ? null : value.clone();
   }
 
   /**
@@ -266,7 +266,7 @@ public class ResponseMessage extends BaseMessage {
    * @return The revid of the document.
    */
   public byte[] getRevID() {
-    return revid;
+    return revid == null ? null : revid.clone();
   }
 
   public ByteBuffer getBytes() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
fndbugs:EI_EXPOSE_REP2 Malicious code vulnerability - May expose internal representation by incorporating reference to mutable object

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=findbugs:EI_EXPOSE_REP2

Please let me know if you have any questions.

Zeeshan
