### PR TITLE
Code Improvments: remove enum static, rename fields and methods, create final static

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -457,7 +457,7 @@ public class ConnectionFactoryBuilder {
   /**
    * Type of protocol to use for connections.
    */
-  public static enum Protocol {
+  public enum Protocol {
     /**
      * Use the text (ascii) protocol.
      */
@@ -471,7 +471,7 @@ public class ConnectionFactoryBuilder {
   /**
    * Type of node locator to use.
    */
-  public static enum Locator {
+  public enum Locator {
     /**
      * Array modulus - the classic node location algorithm.
      */

--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -106,6 +106,7 @@ public class OperationFuture<T>
    * @deprecated
    * @return true if the operation has not yet been written to the network
    */
+  @Deprecated
   public boolean cancel(boolean ign) {
     assert op != null : "No operation";
     op.cancel();

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -59,7 +59,7 @@ public abstract class BaseOperationImpl extends SpyObject implements Operation {
       new TimedOutOperationStatus();
   private volatile OperationState state = OperationState.WRITE_QUEUED;
   private ByteBuffer cmd = null;
-  private boolean cancelled = false;
+  private boolean isCancelled = false;
   private OperationException exception = null;
   protected OperationCallback callback = null;
   private volatile MemcachedNode handlingNode = null;
@@ -102,7 +102,7 @@ public abstract class BaseOperationImpl extends SpyObject implements Operation {
   }
 
   public final synchronized boolean isCancelled() {
-    return cancelled;
+    return isCancelled;
   }
 
   public final boolean hasErrored() {
@@ -114,7 +114,7 @@ public abstract class BaseOperationImpl extends SpyObject implements Operation {
   }
 
   public final synchronized void cancel() {
-    cancelled = true;
+    isCancelled = true;
 
     synchronized (clones) {
       Iterator<Operation> i = clones.iterator();

--- a/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
@@ -40,16 +40,16 @@ final class StatsOperationImpl extends OperationImpl implements StatsOperation {
 
   private static final byte[] MSG = "stats\r\n".getBytes();
 
-  private final byte[] msg;
+  private final byte[] msgBytes;
   private final StatsOperation.Callback cb;
 
   public StatsOperationImpl(String arg, StatsOperation.Callback c) {
     super(c);
     cb = c;
     if (arg == null) {
-      msg = MSG;
+      msgBytes = MSG;
     } else {
-      msg = ("stats " + arg + "\r\n").getBytes();
+      msgBytes = ("stats " + arg + "\r\n").getBytes();
     }
   }
 
@@ -67,7 +67,7 @@ final class StatsOperationImpl extends OperationImpl implements StatsOperation {
 
   @Override
   public void initialize() {
-    setBuffer(ByteBuffer.wrap(msg));
+    setBuffer(ByteBuffer.wrap(msgBytes));
   }
 
   @Override
@@ -77,6 +77,6 @@ final class StatsOperationImpl extends OperationImpl implements StatsOperation {
 
   @Override
   public String toString() {
-    return "Cmd: " + Arrays.toString(msg);
+    return "Cmd: " + Arrays.toString(msgBytes);
   }
 }

--- a/src/main/java/net/spy/memcached/util/DefaultKetamaNodeLocatorConfiguration.java
+++ b/src/main/java/net/spy/memcached/util/DefaultKetamaNodeLocatorConfiguration.java
@@ -35,7 +35,7 @@ import net.spy.memcached.MemcachedNode;
 public class DefaultKetamaNodeLocatorConfiguration implements
     KetamaNodeLocatorConfiguration {
 
-  private final int numReps = 160;
+  private static final int numReps = 160;
 
   // Internal lookup map to try to carry forward the optimisation that was
   // previously in KetamaNodeLocator


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2786 Nested enum should not be declared static
squid:MissingDeprecatedCheck Deprecated elements should have both the annotation and the Javadoc tag
squid:S1845 Methods and field names should not be the same or differ only by capitalization
squid:S1170 Public constants and fields initialized at declaration should be static final rather than merely final

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2786
https://dev.eclipse.org/sonar/coding_rules#q=squid:MissingDeprecatedCheck 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1845
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1170

Please let me know if you have any questions.

Zeeshan
