### PR TITLE
Use LinkedBlockingQueue instead of ArrayBlockingQueue

### DIFF
--- a/src/main/java/net/spy/memcached/metrics/AbstractMetricCollector.java
+++ b/src/main/java/net/spy/memcached/metrics/AbstractMetricCollector.java
@@ -22,19 +22,21 @@
 
 package net.spy.memcached.metrics;
 
+import java.net.SocketAddress;
+
 /**
  * This abstract class implements methods needed by all {@link MetricCollector}s.
  */
 public abstract class AbstractMetricCollector  implements MetricCollector {
 
   @Override
-  public void decrementCounter(String name) {
-    decrementCounter(name, 1);
+  public void decrementCounter(SocketAddress node, String name) {
+    decrementCounter(node, name, 1);
   }
 
   @Override
-  public void incrementCounter(String name) {
-    incrementCounter(name, 1);
+  public void incrementCounter(SocketAddress node, String name) {
+    incrementCounter(node, name, 1);
   }
 
 }

--- a/src/main/java/net/spy/memcached/metrics/DefaultMetricCollector.java
+++ b/src/main/java/net/spy/memcached/metrics/DefaultMetricCollector.java
@@ -26,6 +26,7 @@ import com.codahale.metrics.*;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.net.SocketAddress;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -134,14 +135,14 @@ public final class DefaultMetricCollector extends AbstractMetricCollector {
   }
 
   @Override
-  public void addCounter(String name) {
+  public void addCounter(SocketAddress node, String name) {
     if (!counters.containsKey(name)) {
       counters.put(name, registry.counter(name));
     }
   }
 
   @Override
-  public void removeCounter(String name) {
+  public void removeCounter(SocketAddress node, String name) {
     if (!counters.containsKey(name)) {
       registry.remove(name);
       counters.remove(name);
@@ -149,56 +150,56 @@ public final class DefaultMetricCollector extends AbstractMetricCollector {
   }
 
   @Override
-  public void incrementCounter(String name, int amount) {
+  public void incrementCounter(SocketAddress node, String name, int amount) {
     if (counters.containsKey(name)) {
       counters.get(name).inc(amount);
     }
   }
 
   @Override
-  public void decrementCounter(String name, int amount) {
+  public void decrementCounter(SocketAddress node, String name, int amount) {
     if (counters.containsKey(name)) {
       counters.get(name).dec(amount);
     }
   }
 
   @Override
-  public void addMeter(String name) {
+  public void addMeter(SocketAddress node, String name) {
     if (!meters.containsKey(name)) {
       meters.put(name, registry.meter(name));
     }
   }
 
   @Override
-  public void removeMeter(String name) {
+  public void removeMeter(SocketAddress node, String name) {
     if (meters.containsKey(name)) {
       meters.remove(name);
     }
   }
 
   @Override
-  public void markMeter(String name) {
+  public void markMeter(SocketAddress node, String name) {
     if (meters.containsKey(name)) {
       meters.get(name).mark();
     }
   }
 
   @Override
-  public void addHistogram(String name) {
+  public void addHistogram(SocketAddress node, String name) {
     if (!histograms.containsKey(name)) {
       histograms.put(name, registry.histogram(name));
     }
   }
 
   @Override
-  public void removeHistogram(String name) {
+  public void removeHistogram(SocketAddress node, String name) {
     if (histograms.containsKey(name)) {
       histograms.remove(name);
     }
   }
 
   @Override
-  public void updateHistogram(String name, int amount) {
+  public void updateHistogram(SocketAddress node, String name, int amount) {
     if (histograms.containsKey(name)) {
       histograms.get(name).update(amount);
     }

--- a/src/main/java/net/spy/memcached/metrics/MetricCollector.java
+++ b/src/main/java/net/spy/memcached/metrics/MetricCollector.java
@@ -22,6 +22,8 @@
 
 package net.spy.memcached.metrics;
 
+import java.net.SocketAddress;
+
 /**
  * Defines a common API for all {@link MetricCollector}s.
  *
@@ -42,88 +44,99 @@ public interface MetricCollector {
   /**
    * Add a Counter to the collector.
    *
+   * @param node the memcached node
    * @param name the name of the counter.
    */
-  void addCounter(String name);
+  void addCounter(SocketAddress node, String name);
 
   /**
    * Remove a Counter from the collector.
    *
+   * @param node the memcached node
    * @param name the name of the counter.
    */
-  void removeCounter(String name);
+  void removeCounter(SocketAddress node, String name);
 
   /**
    * Increment a Counter by one.
    *
+   * @param node the memcached node
    * @param name the name of the counter.
    */
-  void incrementCounter(String name);
+  void incrementCounter(SocketAddress node, String name);
 
   /**
    * Increment a Counter by the given amount.
    *
+   * @param node the memcached node
    * @param name the name of the counter.
    * @param amount the amount to increase.
    */
-  void incrementCounter(String name, int amount);
+  void incrementCounter(SocketAddress node, String name, int amount);
 
   /**
    * Decrement a Counter by one.
    *
+   * @param node the memcached node
    * @param name the name of the counter.
    */
-  void decrementCounter(String name);
+  void decrementCounter(SocketAddress node, String name);
 
   /**
    * Decrement a Counter by the given amount.
    *
+   * @param node the memcached node
    * @param name the name of the counter.
    * @param amount the amount to decrease.
    */
-  void decrementCounter(String name, int amount);
+  void decrementCounter(SocketAddress node, String name, int amount);
 
   /**
    * Add a Meter to the Collector.
    *
+   * @param node the memcached node
    * @param name the name of the counter.
    */
-  void addMeter(String name);
+  void addMeter(SocketAddress node, String name);
 
   /**
    * Remove a Meter from the Collector.
    *
    * @param name the name of the counter.
    */
-  void removeMeter(String name);
+  void removeMeter(SocketAddress node, String name);
 
   /**
    * Mark a checkpoint in the Meter.
    *
+   * @param node the memcached node
    * @param name the name of the counter.
    */
-  void markMeter(String name);
+  void markMeter(SocketAddress node, String name);
 
   /**
    * Add a Histogram to the Collector.
    *
+   * @param node the memcached node
    * @param name the name of the counter.
    */
-  void addHistogram(String name);
+  void addHistogram(SocketAddress node, String name);
 
   /**
    * Remove a Histogram from the Collector.
    *
+   * @param node the memcached node
    * @param name the name of the counter.
    */
-  void removeHistogram(String name);
+  void removeHistogram(SocketAddress node, String name);
 
   /**
    * Update the Histogram with the given amount.
    *
+   * @param node the memcached node
    * @param name the name of the counter.
    * @param amount the amount to update.
    */
-  void updateHistogram(String name, int amount);
+  void updateHistogram(SocketAddress node, String name, int amount);
 
 }

--- a/src/main/java/net/spy/memcached/metrics/NoopMetricCollector.java
+++ b/src/main/java/net/spy/memcached/metrics/NoopMetricCollector.java
@@ -22,6 +22,8 @@
 
 package net.spy.memcached.metrics;
 
+import java.net.SocketAddress;
+
 /**
  * A {@link MetricCollector} that does nothing.
  *
@@ -31,52 +33,52 @@ package net.spy.memcached.metrics;
 public final class NoopMetricCollector extends AbstractMetricCollector {
 
   @Override
-  public void addCounter(String name) {
+  public void addCounter(SocketAddress node, String name) {
     return;
   }
 
   @Override
-  public void removeCounter(String name) {
+  public void removeCounter(SocketAddress node,String name) {
     return;
   }
 
   @Override
-  public void incrementCounter(String name, int amount) {
+  public void incrementCounter(SocketAddress node,String name, int amount) {
     return;
   }
 
   @Override
-  public void decrementCounter(String name, int amount) {
+  public void decrementCounter(SocketAddress node,String name, int amount) {
     return;
   }
 
   @Override
-  public void addMeter(String name) {
+  public void addMeter(SocketAddress node,String name) {
     return;
   }
 
   @Override
-  public void removeMeter(String name) {
+  public void removeMeter(SocketAddress node,String name) {
     return;
   }
 
   @Override
-  public void markMeter(String name) {
+  public void markMeter(SocketAddress node,String name) {
     return;
   }
 
   @Override
-  public void addHistogram(String name) {
+  public void addHistogram(SocketAddress node,String name) {
     return;
   }
 
   @Override
-  public void removeHistogram(String name) {
+  public void removeHistogram(SocketAddress node,String name) {
     return;
   }
 
   @Override
-  public void updateHistogram(String name, int amount) {
+  public void updateHistogram(SocketAddress node,String name, int amount) {
     return;
   }
 

--- a/src/main/java/net/spy/memcached/transcoders/TranscodeService.java
+++ b/src/main/java/net/spy/memcached/transcoders/TranscodeService.java
@@ -22,7 +22,7 @@
 
 package net.spy.memcached.transcoders;
 
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -45,7 +45,7 @@ public class TranscodeService extends SpyObject {
 
   public TranscodeService(boolean daemon) {
     pool = new ThreadPoolExecutor(1, 10, 60L, TimeUnit.MILLISECONDS,
-        new ArrayBlockingQueue<Runnable>(100), new BasicThreadFactory(
+        new LinkedBlockingQueue<>(100), new BasicThreadFactory(
           "transcoder", daemon), new ThreadPoolExecutor.DiscardPolicy());
   }
 

--- a/src/main/java/net/spy/memcached/transcoders/TranscodeService.java
+++ b/src/main/java/net/spy/memcached/transcoders/TranscodeService.java
@@ -45,7 +45,7 @@ public class TranscodeService extends SpyObject {
 
   public TranscodeService(boolean daemon) {
     pool = new ThreadPoolExecutor(1, 10, 60L, TimeUnit.MILLISECONDS,
-        new LinkedBlockingQueue<>(100), new BasicThreadFactory(
+        new LinkedBlockingQueue<Runnable>(100), new BasicThreadFactory(
           "transcoder", daemon), new ThreadPoolExecutor.DiscardPolicy());
   }
 

--- a/src/test/java/net/spy/memcached/metrics/DummyMetricCollector.java
+++ b/src/test/java/net/spy/memcached/metrics/DummyMetricCollector.java
@@ -23,6 +23,7 @@
 
 package net.spy.memcached.metrics;
 
+import java.net.SocketAddress;
 import java.util.HashMap;
 
 /**
@@ -37,62 +38,62 @@ public class DummyMetricCollector implements MetricCollector {
   }
 
   @Override
-  public void addCounter(String name) {
+  public void addCounter(SocketAddress node, String name) {
     metrics.put(name, 0);
   }
 
   @Override
-  public void removeCounter(String name) {
+  public void removeCounter(SocketAddress node,String name) {
     metrics.remove(name);
   }
 
   @Override
-  public void incrementCounter(String name) {
+  public void incrementCounter(SocketAddress node,String name) {
     metrics.put(name, metrics.get(name) + 1);
   }
 
   @Override
-  public void incrementCounter(String name, int amount) {
+  public void incrementCounter(SocketAddress node,String name, int amount) {
     metrics.put(name, metrics.get(name) + amount);
   }
 
   @Override
-  public void decrementCounter(String name) {
+  public void decrementCounter(SocketAddress node,String name) {
     metrics.put(name, metrics.get(name) - 1);
   }
 
   @Override
-  public void decrementCounter(String name, int amount) {
+  public void decrementCounter(SocketAddress node,String name, int amount) {
     metrics.put(name, metrics.get(name) - amount);
   }
 
   @Override
-  public void addMeter(String name) {
+  public void addMeter(SocketAddress node,String name) {
     metrics.put(name, 0);
   }
 
   @Override
-  public void removeMeter(String name) {
+  public void removeMeter(SocketAddress node,String name) {
     metrics.remove(name);
   }
 
   @Override
-  public void markMeter(String name) {
+  public void markMeter(SocketAddress node,String name) {
     metrics.put(name, metrics.get(name) + 1);
   }
 
   @Override
-  public void addHistogram(String name) {
+  public void addHistogram(SocketAddress node,String name) {
     metrics.put(name, 0);
   }
 
   @Override
-  public void removeHistogram(String name) {
+  public void removeHistogram(SocketAddress node,String name) {
     metrics.remove(name);
   }
 
   @Override
-  public void updateHistogram(String name, int amount) {
+  public void updateHistogram(SocketAddress node,String name, int amount) {
     metrics.put(name, metrics.get(name) + amount);
   }
 


### PR DESCRIPTION
ArrayBlockingQueue uses the same lock for both get and put, this creates extra contention on the lock and hurts the throughput.
LinkedBlockingQueue on the other hand uses two different locks and performs better in this scenario.