### PR TITLE
Update old net.spy.compat.log class names

### DIFF
--- a/src/main/java/net/spy/memcached/compat/log/Log4JLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/Log4JLogger.java
@@ -63,7 +63,7 @@ public class Log4JLogger extends AbstractLogger {
   /**
    * Wrapper around log4j.
    *
-   * @param level net.spy.compat.log.Level level.
+   * @param level net.spy.memcached.compat.log.Level level.
    * @param message object message
    * @param e optional throwable
    */
@@ -93,9 +93,9 @@ public class Log4JLogger extends AbstractLogger {
     default:
       // I don't know what this is, so consider it fatal
       pLevel = org.apache.log4j.Level.FATAL;
-      l4jLogger.log("net.spy.compat.log.AbstractLogger", pLevel, "Unhandled "
+      l4jLogger.log("net.spy.memcached.compat.log.AbstractLogger", pLevel, "Unhandled "
           + "log level:  " + level + " for the following message", null);
     }
-    l4jLogger.log("net.spy.compat.log.AbstractLogger", pLevel, message, e);
+    l4jLogger.log("net.spy.memcached.compat.log.AbstractLogger", pLevel, message, e);
   }
 }

--- a/src/main/java/net/spy/memcached/compat/log/LoggerFactory.java
+++ b/src/main/java/net/spy/memcached/compat/log/LoggerFactory.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentMap;
  * Factory to get logger instances.
  *
  * The system property <code>net.spy.log.LoggerImpl</code> should point
- * to an implementation of net.spy.compat.log.Logger to use.
+ * to an implementation of net.spy.memcached.compat.log.Logger to use.
  *
  * <p>
  * Depending on how and where this was compiled, a sun logger (jdk 1.4) and/or
@@ -132,13 +132,13 @@ public final class LoggerFactory extends Object {
       } catch (NoClassDefFoundError e) {
         System.err.println("Warning:  " + className
             + " not found while initializing"
-            + " net.spy.compat.log.LoggerFactory");
+            + " net.spy.memcached.compat.log.LoggerFactory");
         e.printStackTrace();
         c = DefaultLogger.class;
       } catch (ClassNotFoundException e) {
         System.err.println("Warning:  " + className
             + " not found while initializing"
-            + " net.spy.compat.log.LoggerFactory");
+            + " net.spy.memcached.compat.log.LoggerFactory");
         e.printStackTrace();
         c = DefaultLogger.class;
       }

--- a/src/main/java/net/spy/memcached/compat/log/SLF4JLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/SLF4JLogger.java
@@ -66,7 +66,7 @@ public class SLF4JLogger extends AbstractLogger {
   /**
    * Wrapper around SLF4J logger facade.
    *
-   * @param level net.spy.compat.log.Level level.
+   * @param level net.spy.memcached.compat.log.Level level.
    * @param message object message
    * @param e optional throwable
    */

--- a/src/main/java/net/spy/memcached/compat/log/SunLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/SunLogger.java
@@ -66,7 +66,7 @@ public class SunLogger extends AbstractLogger {
   /**
    * Wrapper around sun logger.
    *
-   * @param level net.spy.compat.log.AbstractLogger level.
+   * @param level net.spy.memcached.compat.log.AbstractLogger level.
    * @param message object message
    * @param e optional throwable
    */

--- a/src/test/java/net/spy/memcached/compat/log/LoggingTest.java
+++ b/src/test/java/net/spy/memcached/compat/log/LoggingTest.java
@@ -83,7 +83,7 @@ public class LoggingTest extends TestCase {
    */
   public void testLog4j() {
     // Logger l=LoggerFactory.getLogger(getClass());
-    // assertEquals("net.spy.compat.log.Log4JLogger", l.getClass().getName());
+    // assertEquals("net.spy.memcached.compat.log.Log4JLogger", l.getClass().getName());
   }
 
   /**


### PR DESCRIPTION
Looks like an old code refactoring missed a few things.