### PR TITLE
Updated the validateKey exception message

### DIFF
--- a/src/main/java/net/spy/memcached/util/StringUtils.java
+++ b/src/main/java/net/spy/memcached/util/StringUtils.java
@@ -135,7 +135,7 @@ public final class StringUtils {
       for (byte b : keyBytes) {
         if (b == ' ' || b == '\n' || b == '\r' || b == 0) {
           throw new IllegalArgumentException(
-              "Key contains invalid characters:  ``" + key + "''");
+              "Key contains invalid characters:  ''" + key + "''");
         }
       }
     }


### PR DESCRIPTION
The single quotes were different styles.
Suggest keeping them the same so that it prevents confusion if this exception occurs.